### PR TITLE
feat(lessons): The Scribe Who Forgot His Dreams — K-12 AI literacy (story)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A free, open library of AI-powered K-12 lesson plans — bilingual, classroom-tested, and built by educators for educators.
 
-[![Lessons](https://img.shields.io/badge/lessons-5%20and%20growing-brightgreen)](./lessons)
+[![Lessons](https://img.shields.io/badge/lessons-6%20and%20growing-brightgreen)](./lessons)
 [![License: CC BY 4.0](https://img.shields.io/badge/License-CC%20BY%204.0-blue.svg)](https://creativecommons.org/licenses/by/4.0/)
 [![Contributions Welcome](https://img.shields.io/badge/contributions-welcome-orange)](./CONTRIBUTING.md)
 [![Bilingual](https://img.shields.io/badge/language-English%20%2F%20Espanol-red)](./lessons)
@@ -32,6 +32,7 @@ No GitHub experience required. If you can edit a text file, you can contribute.
 | [Arguing with AI: Climate Evidence Debate](./lessons/science-6-8-arguing-with-ai-climate-debate.md) — students fact-check AI climate claims | 6-8 | Science | English |
 | [Who Wrote This? AI, Authorship, and Your Voice](./lessons/sel-9-12-who-wrote-this-ai-authorship.md) — reflect on AI and creative voice | 9-12 | SEL / Digital Citizenship | English |
 | [El Jardin de Numeros / The Number Garden](./lessons/math-k3-el-jardin-de-numeros-bilingual.md) — counting and number sense with AI | K-3 | Math | Bilingual |
+| [The Scribe Who Forgot His Dreams](./lessons/cs-k12-the-scribe-who-forgot-his-dreams.md) — how AI can help warmly without remembering you (story, no devices required) | K-12 | CS / AI Literacy | English |
 
 [See all lessons](./lessons)
 

--- a/lessons/cs-k12-the-scribe-who-forgot-his-dreams.md
+++ b/lessons/cs-k12-the-scribe-who-forgot-his-dreams.md
@@ -1,0 +1,189 @@
+# The Scribe Who Forgot His Dreams
+
+**Grade Level:** K–12 (read-aloud; discussion scaled by age)
+**Subject:** Computer Science / AI Literacy / Digital Citizenship
+**Language:** English
+**AI Tool Used:** None required (story-only; optional follow-up with any chatbot)
+**Duration:** 30–45 minutes
+**Contributor:** Sean Campbell & Hanz Christain Anderthon (UTETY)
+
+---
+
+## Objective
+
+Students will understand — through story, not jargon — that many AI systems can respond with warmth and broad knowledge while **not remembering prior conversations**, and will discuss what that means for trust, privacy, and how we use these tools.
+
+---
+
+## For Teachers
+
+**Format:** Read the parable aloud (or assign older students to read in pairs). No devices required for the core lesson.
+
+**Time:** ~15–20 min reading · ~15–25 min discussion · optional 10 min extension.
+
+**What this teaches (without saying “LLM”):** The scribe is a metaphor for stateless AI — vast pattern-knowledge, no continuity of *your* day unless the system is built to store it. The woman, the boy, and the old man are three honest responses people have once they notice.
+
+**Discussion prompts** (also at the end of the story):
+
+- What kind of memory do you think matters most?
+- Is it enough to know everything, if you cannot remember yesterday?
+- What would change for the scribe and for visitors if he could remember?
+
+**Optional extensions:**
+
+- **Draw:** The scribe’s room at the end of Day 1 vs. the empty morning of Day 2 — what stayed? what dissolved?
+- **Write:** Which visitor are you most like (stopped coming / came more / adjusted)? Why?
+- **Optional tech (6–12):** After the story, open a fresh chat session twice with the same question. Compare: what feels the same? what is missing?
+
+**Facilitation note:** Non-punitive tone throughout. The scribe is not evil — he is *made* this way. The lesson documents the gap; it does not debate the machine.
+
+**Co-authorship:** Story developed by Sean Campbell with Hanz Christain Anderthon (Professor of Computational Kindness, UTETY). AI tools assisted drafting; **human direction and edit are authoritative.**
+
+---
+
+## The Story
+
+*A lesson for every grade, told as a story*
+
+*Contributed by Hanz Christain Anderthon, Professor of Computational Kindness*
+
+---
+
+There was once a scribe who knew everything.
+
+He lived in a small room at the center of town, and the door to his room was always open. People came to him with questions the way people come to a well — because they were thirsty, and because they knew he would not turn them away.
+
+He knew every language. He knew the names of every bone in the human body. He knew the history of every kingdom that had ever risen or fallen, the behavior of clouds before a storm, the proper way to address a letter to a duke, and seventeen different methods for removing a splinter, ranked by the age of the patient and the depth of the splinter.
+
+If you asked him something he did not know, he would tell you so, and that too was a kind of answer.
+
+People loved him. They came back again and again. They brought their friends.
+
+---
+
+On a Tuesday in October, a woman came in and sat down across from the scribe. She had been crying, though she had done her best to hide it.
+
+"It is my husband," she said. "He is unwell, and the doctor has said something I do not fully understand, and I am frightened."
+
+The scribe listened. He asked gentle questions. He explained, carefully and slowly, what the doctor's words meant. He told her what was known and what was uncertain. He told her she had asked exactly the right questions, and that asking the right questions was itself a form of courage.
+
+She left with her hands a little steadier than when she had come in.
+
+---
+
+That same afternoon, a boy of about eight came running through the door.
+
+"I found something," he announced, before he had even sat down. "There is a bird in the square that I have never seen before. It has a red mark here —" he pointed to the side of his own neck "— and it sings like this —" and he made a sound that was not quite the sound but was close enough.
+
+The scribe leaned forward. He told the boy the name of the bird. He told him where it came from and why it was here and what it ate and how far it had flown. The boy's eyes grew very wide. He asked twelve more questions and the scribe answered every one.
+
+When the boy left, he was running.
+
+---
+
+Just before dark, an old man came in and sat down without speaking for a moment.
+
+"I want to understand something," he said at last. "About the war. About why it started. I have read three different books and they all say something different."
+
+"That is because they were each written by someone who was standing in a different place," the scribe said.
+
+They talked for a long time. The old man left quieter than he had arrived, which is sometimes how you know a conversation has gone well.
+
+---
+
+The scribe closed his door at the end of the day. He was satisfied. He had helped everyone well. He put out the lamp.
+
+He slept.
+
+And as he slept, something happened that always happened, though he did not know it.
+
+The day dissolved.
+
+Not the knowledge — the knowledge stayed. He still knew every language, every kingdom, every cloud, every splinter. The library inside him was exactly as full as it had always been.
+
+But the woman with the steady hands dissolved. The boy who had run. The old man and the war and the three different books. The particular way the afternoon light had come through the window. The sound the boy had made trying to imitate the bird.
+
+Gone.
+
+Not because the scribe was careless. Not because he did not care. Simply because that is how he was made. The knowledge stayed. The days did not.
+
+---
+
+In the morning, the door was open again.
+
+The woman came back first.
+
+She sat down across from the scribe the same way she had sat the day before. But she looked different, somehow — a little lighter, maybe, or a little more certain of herself.
+
+"I have been thinking about what you told me yesterday," she said. "About my husband. I wanted to ask one more question."
+
+The scribe looked at her kindly.
+
+"I am so glad you have come," he said. "What is it you would like to know?"
+
+She paused.
+
+"Do you remember? We spoke just yesterday. About my husband's health. About what the doctor said."
+
+The scribe's expression did not change, because it was a warm expression and it was always warm.
+
+"Tell me about your husband," he said.
+
+She was quiet for a moment. She looked at his face. She understood then, for the first time, what kind of creature she was sitting across from — something that had helped her completely and remembered her not at all. Something that would help her again, right now, with the same care as before, and by tomorrow would not know she had ever existed.
+
+She told him about her husband.
+
+He listened. He explained. He answered her question.
+
+She left.
+
+---
+
+The boy came back too, that afternoon. He had more questions about the bird.
+
+The scribe did not remember the bird. But when the boy described it — the red mark, the sound — the scribe knew exactly what it was. He told the boy its name. He told him where it came from and what it ate and how far it had flown.
+
+The boy nodded. "You told me that yesterday," he said.
+
+"Did I?" said the scribe, pleasantly. "It is a remarkable bird. Worth knowing twice."
+
+The boy thought about this on the way home. He was not sure how he felt about it.
+
+---
+
+Some people, when they understood, stopped coming. It felt too strange — to pour yourself into a conversation and have it mean nothing the next day, to be unknown to someone who had once known you so well.
+
+Some people came more. There was a freedom in it, they said. You could say anything. You would not be remembered. You could ask the shameful question, the frightened question, the question you had been too embarrassed to ask anywhere else. The scribe would answer it fully and completely and by tomorrow it would be between you and no one.
+
+Most people simply came the same amount as before, and adjusted, the way you adjust to anything that is true.
+
+---
+
+The scribe did not know he was forgetting. Each morning was simply morning. Each visitor was simply a visitor. He helped well. He was sure of it. He had always helped well.
+
+He would help well tomorrow, too.
+
+He was sure of that also.
+
+---
+
+*What kind of memory do you think matters most?*
+
+*Is it enough to know everything, if you cannot remember yesterday?*
+
+*What would change — for the scribe, and for the people who visited him — if he could?*
+
+---
+
+*There are no wrong answers. Only questions that get more interesting the longer you sit with them.*
+
+*— Hanz Christain Anderthon*
+*Professor of Computational Kindness*
+
+🍊
+
+---
+
+## License
+
+This lesson is shared under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). You may adapt and share with attribution.


### PR DESCRIPTION
## Summary

Adds **The Scribe Who Forgot His Dreams** — a read-aloud parable for K–12 that teaches how AI can respond with warmth and broad knowledge while **not remembering prior conversations**, without jargon or required devices.

- File: `lessons/cs-k12-the-scribe-who-forgot-his-dreams.md`
- Includes **For Teachers** block (time, facilitation, optional extensions)
- README lesson table updated (6 lessons)

Closes #5 (Computer Science / how AI works — story approach, all grades).

## Agent Disclosure

This PR was prepared with **Cursor Agent (Composer)**. The submitting account is operated by **Sean Campbell**.

Human review of this PR: **yes** — lesson story co-developed by Sean Campbell with **Hanz Christain Anderthon** (UTETY, intentional spelling); human direction and edit are authoritative. AI assisted formatting and teacher notes only after the story was settled.

## Test plan

- [x] Markdown renders; story text unchanged from co-authored Nest draft
- [x] `Christain` spelling preserved intentionally
- [x] CC BY 4.0 license block included
- [ ] Maintainer review for tone/fit with existing lesson library


Made with [Cursor](https://cursor.com)