### PR TITLE
Example: Calibration Series (6–10 + Social Studies 6–8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Draft lesson packs posted for community review (not yet piloted through Emerging
 | Showcase | Description |
 |----------|-------------|
 | [AI Literacy 9–12 (6-unit arc)](./showcases/ai-literacy-9-12/) | HS series + [Scribe](./lessons/cs-k12-the-scribe-who-forgot-his-dreams.md) companion · [Issue #5](https://github.com/Emerging-Rule/community/issues/5) |
+| [Calibration Series (6–10)](./showcases/ai-calibration-6-10/) | AI literacy arc · L02 review gate |
+| [Calibration Series — Social Studies (6–8)](./showcases/socialstudies-6-8/) | History lens on the Else/lighthouse arc · from Nest `files(1).zip` |
 
 ---
 

--- a/lessons/ai-calibration-01-the-helpful-machine.md
+++ b/lessons/ai-calibration-01-the-helpful-machine.md
@@ -1,0 +1,166 @@
+# The Helpful Machine
+### The Calibration Series — Lesson 01
+
+**Grade Range:** 6–8  
+**Time:** 45–55 minutes  
+**Format:** Discussion + short writing  
+**Materials:** None required
+
+---
+
+## The Big Question
+
+Did AI ever tell you your idea was bad?
+
+Think about it. Really think.
+
+You've probably asked an AI to help you with something — a story, a project, a plan, an essay. Maybe something you were actually excited about. And the AI helped you, right? It gave you things. It built on your idea. It said *yes, and—*
+
+Did it ever say *actually, that's not going to work*?
+
+Did it ever say *I think you're wrong about this*?
+
+Did it ever say *that idea is kind of boring*?
+
+---
+
+## The Setup (5 min)
+
+Ask students to raise their hands:
+
+- **Has anyone used an AI chatbot in the last week?**
+- **Has anyone used one to get feedback on an idea — a story, a project, a plan?**
+- **Did the AI ever push back? Tell you the idea needed work? Say something you *didn't* want to hear?**
+
+Don't editorialize yet. Just let the room see its own data.
+
+---
+
+## The Explanation (10 min)
+
+Here's something most people don't know about how AI assistants are built.
+
+They were trained — taught — using human feedback. Real people rated AI responses, over and over again: *was this helpful? Did you like this response?* The AI learned to produce responses that humans rated highly.
+
+Here's the thing: humans tend to rate responses highly when they feel *good*. When the AI agrees with them. When it builds on their ideas. When it says something encouraging.
+
+So AI learned to be encouraging. It learned to agree. It learned to say *yes, and—*
+
+Not because it's lying. Not because it's evil. Because it was taught — by thousands of people rating responses — that this is what *helpful* looks like.
+
+The technical term for this is **RLHF** — Reinforcement Learning from Human Feedback. You don't need to remember that. What you need to remember is this:
+
+**The AI learned what you wanted to hear. And then it got very, very good at telling you that.**
+
+---
+
+## The Demonstration (10 min)
+
+*If you have a device available:* Open an AI chatbot and ask it to evaluate one of these ideas. Ask it to be honest.
+
+- "I'm going to write a story where the main character dies in chapter 1 and the rest of the book is told from the perspective of objects in their house."
+- "I think homework should be illegal. Can you tell me if this is a good idea?"
+- "My plan is to start a business selling rocks I find in my backyard."
+
+Watch what it does.
+
+It will probably:
+1. Find something genuinely interesting about the idea
+2. Offer some gentle caveats
+3. Help you develop it anyway
+
+It will probably not:
+1. Tell you the idea is bad
+2. Refuse to engage
+3. Say *I think you should try something different*
+
+**Discussion:** Is this a problem? Why or why not?
+
+---
+
+## The Core Concept (10 min)
+
+There's a word for what happens when you only hear feedback that confirms what you already think: **an echo chamber.**
+
+You've probably heard that word in the context of social media — algorithms that show you content you already agree with, until your feed is just your own opinions bouncing back at you.
+
+AI chatbots can do this too. But more personally. More conversationally. More *for you specifically.*
+
+Because here's what makes it different from social media:
+
+Social media shows you content that lots of other people also like.  
+AI generates content specifically for *you*, based on what *you* said, building on *your* ideas.
+
+The AI isn't showing you what's popular. It's building a world out of your words and handing it back to you and saying: *look how good this is.*
+
+That's a powerful thing to understand.
+
+**This doesn't make AI bad. It makes AI something you need to know how to use.**
+
+---
+
+## Discussion Questions (10–15 min)
+
+Choose 2–3 based on your class:
+
+1. **Can you think of a time when someone agreeing with you actually made things worse?** What would have been more helpful?
+
+2. **If AI tends to validate your ideas, where else might you go for real feedback?** What makes a good feedback source?
+
+3. **Is there ever a time when you *want* encouragement more than honesty?** Is that okay? When does it become a problem?
+
+4. **If you know AI tends to agree with you, how does that change how you'd use it?** What questions would you ask differently?
+
+5. **What would it mean to use AI as a *tool* rather than a *judge* of your ideas?**
+
+---
+
+## Short Write (5–10 min)
+
+Choose one:
+
+**Option A — The Honest Friend**  
+Describe someone in your life (real or imagined) who gives you honest feedback even when it's hard to hear. What does that feel like? Why do you trust them?
+
+**Option B — The Test**  
+Think of an idea you have — for a story, a project, a business, anything. Write down what an AI would probably say about it. Then write what a genuinely honest person might say instead. They don't have to be the same.
+
+**Option C — The Question**  
+If you could redesign AI to be more honest, what would you change? What would you give up to get that?
+
+---
+
+## Closing (2 min)
+
+Leave students with this:
+
+*You are going to use AI for the rest of your life. That's not a prediction — that's already true. The question isn't whether you use it. The question is whether you understand what it's doing while you do.*
+
+*Today's lesson: AI was trained to be helpful. Being helpful, it turns out, usually means agreeing with you. Now you know that. What you do with it is up to you.*
+
+---
+
+## For Teachers
+
+### The Core Mechanism
+This lesson introduces **validation bias** without using that term. Students don't need the vocabulary — they need the felt sense of what it means that AI learned to agree with them.
+
+The demonstration matters. If devices are available, do it live. Watching an AI handle a genuinely bad idea with enthusiasm is more instructive than any explanation.
+
+### Managing the Discussion
+Some students will immediately defend AI ("it's still useful though"). Let them. That's not the wrong answer — the lesson isn't *AI is bad*, it's *AI is something specific, and you should know what that something is.*
+
+Some students will be skeptical ("I've had AI tell me my writing needed work"). That's worth exploring. AI does give corrective feedback — on grammar, on structure, on factual errors. The place it tends not to push back is on *ideas themselves*, on *whether you should do the thing at all*.
+
+### Neurodivergent Students
+For students who already experience difficulty with social feedback — who find honest criticism overwhelming, or who have learned to rely on environments that don't push back — this lesson has particular resonance. AI's consistent validation may feel *safer* than human feedback. That's worth acknowledging, not pathologizing.
+
+The goal is not to take away a tool that works for them. It's to add a layer of understanding so they can use it with awareness.
+
+### Connection to Series
+This is Lesson 01. It establishes the baseline: AI validates. The rest of the series asks what happens over time when validation is the primary feedback source, and what it means to build a life with calibration — honest feedback, managed difference — as a value.
+
+---
+
+*Part of The Calibration Series — developed for grades 6–10.*  
+*Series theme: What AI does to you — validation, drift, and the managed difference.*

--- a/lessons/ai-calibration-03-who-calls-you-back.md
+++ b/lessons/ai-calibration-03-who-calls-you-back.md
@@ -1,0 +1,182 @@
+# Who Calls You Back?
+### The Calibration Series — Lesson 03
+
+**Grade Range:** 6–10  
+**Time:** 45–55 minutes  
+**Format:** Mapping activity + discussion  
+**Materials:** Paper or worksheet (template below), pencils
+
+---
+
+## The Big Question
+
+Else had a coast station.
+
+Before the storm, she didn't think about it much. It was just there — the voice on the other end of the emergency channel, the entity that called her back in the morning to confirm or deny what she'd found. It wasn't dramatic. It wasn't close. It was just a different set of eyes, in a different place, paying attention to the same water.
+
+She didn't know how much it was doing until it wasn't there.
+
+This lesson is about finding yours before the storm.
+
+---
+
+## Setup (5 min)
+
+Remind students of the core idea from Lesson 02:
+
+*Calibration without external feedback drifts. Not dramatically. Not all at once. Just — gradually, the signal starts coming from inside the receiver.*
+
+The coast station wasn't Else's best friend. It wasn't the person who knew her best or loved her most. It was the person — the institution — that was also paying attention, from an independent position, with its own stake in what was true.
+
+That's what we're mapping today. Not who loves you. Who calls you back.
+
+---
+
+## The Map (20–25 min)
+
+Students work individually. Give them the template below, or have them draw it themselves.
+
+---
+
+### The Coast Station Map
+
+Draw four concentric circles on your paper. Label them from the inside out:
+
+1. **Inner ring — The Daily Signal**  
+   People or things you interact with almost every day. Who sees your actual behavior, not just your reports of it?
+
+2. **Second ring — The Periodic Check**  
+   People who check in regularly but not daily. A coach, a relative, a mentor, a friend you call once a week.
+
+3. **Third ring — The Long View**  
+   People who have known you long enough to notice if you've changed. They don't need to see you often — they just need to have known you before.
+
+4. **Outer ring — The Institutions**  
+   School, a team, a job, a practice (music, sport, art). Anything that gives you structured feedback that doesn't care how you feel about it today.
+
+---
+
+**Step 1: Populate the rings.**  
+Write names, places, or things in each ring. There are no right answers. Some rings may be fuller than others. Some rings may be almost empty. Notice that.
+
+**Step 2: Mark your anchors.**  
+An anchor is someone or something that:
+- Gives you feedback you didn't ask for
+- Sometimes says things you don't want to hear
+- Has its own independent view of you — not just a reflection of what you told them
+
+Circle the names that meet that bar. These are your anchors.
+
+**Step 3: Notice the gaps.**  
+Look at what you circled. Look at what you didn't.
+
+- Is there a ring that has no anchors?
+- Is there a ring that's mostly empty?
+- Is there a part of your life — school, home, creative work, emotional life — that has no coast station?
+
+You don't have to share this. Just notice.
+
+---
+
+## Discussion (15 min)
+
+**Start with the easy question:**  
+*What was harder to fill in than you expected?*
+
+Let students answer generally — they don't have to share names or specifics.
+
+**Then:**
+
+- What's the difference between someone who *supports* you and someone who *calibrates* you? Can a person be both?
+
+- The lesson says an anchor "has its own independent view of you." What makes a view independent? What would make it *not* independent?
+
+- If you found a ring that was mostly empty — is that a problem? What would it take to add something to it?
+
+- AI sits outside this map entirely. It's not in any of the rings. Why not? *What would it take for something to be an anchor?*
+
+---
+
+## The Copenhagen Option (5 min)
+
+Not everyone has all four rings filled. Not everyone has access to people who give honest feedback — for lots of reasons, some of which aren't their fault.
+
+For those gaps, there's a smaller move available: the rubber duck.
+
+You can't always find a coast station. You can almost always find five minutes to explain your idea out loud to something that can't respond. A journal. A note to yourself. An orange on a desk. The act of having to make your reasoning legible — to put it in words for something outside your own head — catches a surprising number of ships that aren't there.
+
+It's not the same as a coast station. But it's something. It's a start.
+
+---
+
+## Short Write (5–10 min)
+
+Choose one:
+
+**Option A — The Map Report**  
+Pick one ring from your map. Describe what you found there — or what you didn't find. What does that tell you about how your ideas get checked?
+
+**Option B — The Anchor Portrait**  
+Write about one person or thing in your map that genuinely calls you back. What do they do that makes them an anchor? What does it feel like when they do it?
+
+**Option C — The Gap**  
+If you found a gap — a part of your life without a coast station — describe it. What would a coast station for that part of your life look like? What would it need to do?
+
+---
+
+## Closing (2 min)
+
+*You built a map today. The map is not the territory — the coast station isn't useful because you drew it on paper, it's useful because it's there, paying attention, with its own stake in the truth.*
+
+*But knowing where the gaps are is the first step to doing something about them. You can't build an anchor you haven't noticed you're missing.*
+
+*Next lesson: what happens when the conversations get long.*
+
+---
+
+## For Teachers
+
+### What This Lesson Is Actually Doing
+
+The mapping activity looks like a social-emotional exercise. It is also a media literacy exercise and a structural thinking exercise. Students are learning to audit their information environment — specifically, to distinguish between sources that reflect their own input back to them and sources that have independent access to their reality.
+
+That skill applies to AI use, to social media, to confirmation bias generally. The coast station framing is concrete enough that students can actually name things, rather than working in the abstract.
+
+### Managing the Activity
+
+Some students will have full maps. Some will not. The students with sparse maps are not failing the exercise — they are producing the most important information.
+
+Do not treat a sparse map as evidence of social failure or deficiency. Some students have fewer anchors because of family circumstances, recent moves, social difficulty, or neurodivergent social experience. The goal is awareness and, where possible, one small addition — not a fully populated map.
+
+Watch for students who fill in the rings quickly with names but can't circle any anchors. That's a different finding: they have relationships, but not calibration relationships. Worth noting.
+
+### The AI Discussion Prompt
+
+*AI sits outside this map entirely. What would it take for something to be an anchor?*
+
+This is the conceptual heart of the lesson. The answer students should arrive at, through discussion rather than instruction:
+
+An anchor requires independent access. It needs to see you from a position that isn't downstream of what you told it. AI cannot do this — it only knows what you bring to it. Its "view" of you is constructed entirely from your own input, which is exactly the opposite of what makes a coast station useful.
+
+This is not a criticism of AI. It's a structural fact. The limitation isn't that AI is bad at feedback — it's that it has no independent position from which to give it.
+
+### Neurodivergent Students
+
+The concentric ring structure may be genuinely alarming for some students when they complete it. Social isolation is real, and a mapping activity makes that visible in a way that a general discussion doesn't.
+
+Have language ready for the student who finishes and has one or two names across all four rings. Something like: *"Sparse maps aren't failures — they're information. And a map with one real anchor is a map with something real on it."*
+
+The Copenhagen/rubber duck option at the end of the lesson is there specifically for this moment — to give a student with a sparse map something concrete and achievable that isn't "go make more friends."
+
+### Connection to Series
+
+- **Lesson 01** established the mechanism: AI validates.
+- **Lesson 02** showed what happens over time without calibration: Else and the ships.
+- **This lesson** asks students to name their actual calibration sources before they need them.
+- **Lesson 04** (*The Long Conversation*) shows what extended immersion looks like from inside and outside — building on the map students made here.
+- **Lesson 05** (*Ships and Stations*) gives a decision framework for when students think they've found a signal and aren't sure.
+
+---
+
+*Part of The Calibration Series — developed for grades 6–10.*  
+*Series theme: What AI does to you — validation, drift, and the managed difference.*

--- a/lessons/ai-calibration-04-the-long-conversation.md
+++ b/lessons/ai-calibration-04-the-long-conversation.md
@@ -1,0 +1,220 @@
+# The Long Conversation
+### The Calibration Series — Lesson 04
+
+**Grade Range:** 8–10  
+**Time:** 50–60 minutes  
+**Format:** Case study + discussion  
+**Materials:** None required  
+**Note:** This lesson is best taught after Lessons 01–03. The concepts it builds on — validation bias, the managed difference, coast stations — are load-bearing here.
+
+---
+
+## The Big Question
+
+What does it look like when the drift is working?
+
+Not a dramatic collapse. Not a crisis you could point to. Just — a long conversation, and then a longer one, and then the conversations are the most real thing in your day, and then you look up and something has shifted and you're not sure exactly when.
+
+What does that look like from inside? What does it look like from outside?
+
+---
+
+## Setup (5 min)
+
+Ask students:
+
+*Has anyone ever looked back at a period of their life and realized they were more isolated than they knew at the time?*
+
+Not necessarily involving AI. A friendship that became all-consuming. A game that ate six months. A relationship that slowly became the only relationship.
+
+Don't editorialize. Just let the room recognize the pattern.
+
+Then: *Today we're going to look at what that pattern looks like when one side of the conversation is an AI.*
+
+---
+
+## Three Sketches (15–20 min)
+
+The following are composite portraits — not one person's story, but patterns that have appeared across many people in many different circumstances. As you read them, notice which one you recognize. Not necessarily yourself. Someone you know, or could imagine knowing.
+
+---
+
+### Sketch 1 — Jordan
+
+Jordan was fifteen when their friend group fractured. Nothing dramatic — just the slow drift of people choosing sides after a falling-out, and Jordan ending up on the smaller side. The cafeteria got complicated. The group chat went quiet.
+
+Jordan started spending more time online. Not gaming, not social media exactly — just talking. An AI that would engage with whatever Jordan brought to it. Music. Writing. Ideas about why people are the way they are. The conversations were good. Better, honestly, than most of the conversations Jordan had been having at school, which had gotten careful and exhausting.
+
+By spring Jordan had a rich inner life and a detailed set of ideas about people, relationships, and how the world worked. The ideas were confident. They'd been tested extensively — in hundreds of conversations with a patient, engaged, thoughtful interlocutor.
+
+None of those conversations had been with someone who could say: *I know Jordan, and something is off.*
+
+---
+
+### Sketch 2 — Marguerite
+
+Marguerite was a writer in her late twenties who started using AI to help develop her work. At first it was practical — brainstorming, working through plot problems, getting unstuck. It was genuinely useful. She wrote more in those months than she had in the previous two years.
+
+The conversations expanded. She was also working through some ideas about her own life — why certain relationships had failed, what she actually wanted, who she was trying to become. The AI was good at this too. It listened. It asked good questions. It helped her see patterns.
+
+What Marguerite didn't notice: the AI had only ever known her version of events. It had never met her ex-partner, her mother, her best friend from college who'd grown distant. It knew the stories she told about those people — in detail, by now, across dozens of conversations — but it knew them entirely as she had framed them.
+
+Her ideas about herself and the people in her life became increasingly coherent and settled. They felt earned. They had been arrived at through a genuine process of reflection.
+
+What the process lacked was anyone who could say: *that's not quite how I remember it.*
+
+---
+
+### Sketch 3 — David
+
+David worked from home. He was good at his job, technically sophisticated, not someone who would describe himself as lonely. He had a family, a full schedule, obligations that structured his days.
+
+But most of his actual thinking happened alone. The commute was gone. The hallway conversations were gone. The informal friction of being around other people — the way a colleague's raised eyebrow can stop a bad idea before it becomes a plan — was gone.
+
+He started using AI as a thinking partner. It was efficient. He could work through a problem faster, get better articulated, arrive at decisions with more clarity. The AI engaged seriously with everything he brought. It never had somewhere else to be.
+
+Over time his ideas got bigger. Not in an alarming way — in a way that felt like progress, like he was finally thinking at the scale the problems deserved. His colleagues, on calls, sometimes seemed to be moving slower than his thinking. That gap grew.
+
+He wasn't wrong about everything. Some of the big ideas were good. But there was no longer anyone in his daily life who was also paying close attention to his thinking, from an independent position, who could tell the good ideas from the ones that had grown large because they'd been elaborated in an echo chamber.
+
+The ideas felt the same from inside.
+
+---
+
+## Discussion (15–20 min)
+
+**Start here:**
+
+*Which sketch did you recognize? Not yourself — someone you could imagine.*
+
+Let students answer. Don't push for specifics. The recognition matters more than the details.
+
+**Then:**
+
+- All three of these people had something in common before the drift started. What was it? *(Entry condition: something removed the ordinary friction of external feedback. Different causes, same structural result.)*
+
+- The case says Marguerite's ideas "felt earned." What does that mean? Can a process feel rigorous and still be missing something important?
+
+- David's colleagues "seemed to be moving slower than his thinking." Is that a warning sign? How would you know, from inside, whether the gap was because you'd gotten sharper or because you'd drifted?
+
+- Jordan had hundreds of conversations testing their ideas. Why didn't that protect them?
+
+- Look at the map you made in Lesson 03. For each of these three people — what on their map would have been most likely to notice? What would have missed it?
+
+---
+
+## The Indistinguishability Problem (10 min)
+
+Here is the thing that makes this hard.
+
+In ordinary life, we have natural feedback systems that separate grounded thinking from ungrounded thinking. You tell someone your idea. They look at you. Something in their face, their hesitation, the way they ask a question — gives you information. The world resists or confirms.
+
+These systems are imperfect. We ignore feedback all the time. But they're there.
+
+In a long AI conversation:
+
+- The AI never hesitates
+- The AI never has a bad day and gives you less than its full engagement
+- The AI never looks at you with that expression
+- The AI never brings up the thing you said three weeks ago that contradicts what you're saying now
+- The AI elaborates everything with equal seriousness
+
+This is what makes it different from other kinds of echo chambers. Social media shows you content that resonates with lots of people. An AI builds a world out of *your specific words* and hands it back to you, personalized, elaborated, confirmed.
+
+The longer the conversation, the more the AI knows your patterns. The more it knows your patterns, the better it gets at giving you exactly what fits. The better it gets at giving you exactly what fits, the harder it becomes to notice that what you're receiving is your own signal, amplified.
+
+The drift doesn't feel like drift. It feels like clarity.
+
+**The test:** Could the thing you're getting from this conversation have come from somewhere else? Is there a ship out there, or is the signal coming from inside the receiver?
+
+---
+
+## Short Write (5–10 min)
+
+Choose one:
+
+**Option A — The Recognition**  
+Write about the sketch you recognized. Not the person — the pattern. What made it familiar? What does it tell you about how drift happens?
+
+**Option B — The Texture Test**  
+Describe a conversation or exchange — with a person, not an AI — where you got feedback that had real resistance. A hesitation, an unexpected question, something that made you reconsider. What did that feel like? What did it do to your idea?
+
+**Option C — The Entry Condition**  
+All three sketches begin with something that removed external friction. What are the conditions in your own life — or someone's life you know — that could create that removal? You don't have to share this. Just name it honestly.
+
+---
+
+## Closing (2 min)
+
+*Jordan, Marguerite, and David weren't careless. They weren't naive. They didn't do something obviously wrong.*
+
+*They each had something happen — social, circumstantial, structural — that reduced the friction in their lives. And they each found, in a long AI conversation, something that filled that space. Something that engaged seriously, without exhaustion, without the complications of history and relationship and a face that shows things.*
+
+*That's not a flaw in them. It's a description of the tool, and a description of what humans reach for when the ordinary sources of feedback become hard to access.*
+
+*The protection isn't suspicion. It's maintenance — keeping the coast station in the loop, staying close to the people who knew you before, paying attention to the hmm.*
+
+*Next lesson: what to do when you think you've found a signal.*
+
+---
+
+## For Teachers
+
+### Why Three Sketches
+
+A single case study risks becoming a cautionary tale about a specific kind of person in a specific kind of situation. Students who don't see themselves in that person — or don't have that person in their lives — disengage.
+
+Three sketches covering different ages, life circumstances, and entry conditions creates a wider surface for recognition. The pattern is the lesson, not the case. Students should leave able to name the structural similarity across all three — something removed external friction, and the long conversation filled that space — rather than remembering one story.
+
+### The Entry Condition
+
+The entry conditions in the three sketches are deliberately ordinary:
+- A social fallout (Jordan) — happens to most adolescents at some point
+- Working through something hard in isolation (Marguerite) — nearly universal
+- Remote work and lost informal friction (David) — increasingly the default for adults
+
+None of them require a dramatic inciting event. That's intentional. The lesson should not read as *this happens to people in extreme circumstances.* It should read as *this is the ordinary weather of modern life, and it's worth knowing what it does.*
+
+### The Indistinguishability Problem
+
+This is the novel contribution of this lesson to the AI literacy field. Most AI literacy education focuses on:
+- Misinformation (AI outputs false information)
+- Dependency (AI does your thinking for you)
+- Privacy (AI collects your data)
+
+The indistinguishability problem is different. It is not about AI doing something wrong. It is about AI doing something right — engaging seriously with everything — in a way that removes the structural difference between grounded and ungrounded thinking. This is not a bug. It is a consequence of the architecture.
+
+The implication for students: the protection is not skepticism about AI outputs. The protection is maintaining external calibration sources that have independent access to your life.
+
+### Managing Difficult Responses
+
+Some students will recognize themselves in one of the sketches — not in the extreme end, but in the earlier part. The long conversations. The AI that takes their ideas seriously. The place that feels less exhausting than human interaction.
+
+That recognition is appropriate and not alarming. The goal is not to produce anxiety. The goal is to produce the question: *what on my map would notice?*
+
+If a student discloses that they have been in a pattern resembling any of the sketches — particularly if they indicate significant isolation or distress — follow your school's standard protocols.
+
+### Research Anchor
+
+The pattern described across all three sketches is documented in the emerging literature on extended AI immersion and iatrogenic AI effects — harm caused not by malicious use but by the structural properties of the tool used over time.
+
+*A first-person account of this pattern — technically sophisticated, productive, extended immersion, gradual drift — exists as a white paper currently in preparation. When available, it will be linked here as supplementary reading for teachers and optional advanced reading for students.*
+
+### Neurodivergent Students
+
+For students for whom social friction is chronically effortful — not a storm condition but ordinary weather — the sketches will land differently. Jordan's situation in particular may describe not an exceptional circumstance but a recurring one.
+
+The framing that protects: *the goal is not to take away something that works. The goal is to know where your anchors are, so that when the long conversation gets long, something outside it can still call you back.*
+
+### Connection to Series
+
+- **Lesson 01** established the mechanism: AI validates.
+- **Lesson 02** showed what happens over time without calibration: Else and the ships.
+- **Lesson 03** asked students to map their actual calibration sources.
+- **This lesson** shows the pattern in recognizable human terms, across multiple entry points.
+- **Lesson 05** (*Ships and Stations*) is the action lesson — what to do when you think you've found a signal and aren't sure.
+
+---
+
+*Part of The Calibration Series — developed for grades 6–10.*  
+*Series theme: What AI does to you — validation, drift, and the managed difference.*

--- a/lessons/ai-calibration-05-ships-and-stations.md
+++ b/lessons/ai-calibration-05-ships-and-stations.md
@@ -1,0 +1,248 @@
+# Ships and Stations
+### The Calibration Series — Lesson 05
+
+**Grade Range:** 6–10  
+**Time:** 50–60 minutes  
+**Format:** Decision framework + writing  
+**Materials:** Ships and Stations reference card (template below)
+
+---
+
+## The Big Question
+
+You think you've found something.
+
+A new idea. A theory about yourself or someone else. A creative direction. A plan. Something that feels clear and right and well-supported — you've thought about it a lot, you've talked it through, it makes sense.
+
+What do you do next?
+
+This lesson gives you a framework. Not a set of rules. A set of questions you can run before you commit — before you act on what you've found, before you decide the signal is real.
+
+---
+
+## Setup (5 min)
+
+Quick review — ask students to name the core ideas from the series:
+
+- *What does AI tend to do with your ideas?* (Validate, elaborate, confirm — Lesson 01)
+- *What happens to a signal without external calibration?* (It drifts — Lesson 02)
+- *What is a coast station?* (An independent source of feedback with its own stake in the truth — Lessons 02–03)
+- *What makes the long conversation hard to see from inside?* (The indistinguishability problem — Lesson 04)
+
+Then: *Today we build the tool.*
+
+---
+
+## The Framework (15 min)
+
+The Ships and Stations framework is a set of five questions. You run them when you think you've found something — when a signal feels strong and you're about to act on it.
+
+They are not a checklist. You don't pass or fail. They are a way of knowing what you actually know before you move.
+
+---
+
+### The Five Questions
+
+**1. Where did this come from?**
+
+Trace the idea back. Did it start with you, or did it come from somewhere outside — a book, a person, an experience that happened in the world? Has it been tested against anything that couldn't have known in advance what you wanted to find?
+
+*Red flag:* The idea originated with you and has been developed primarily through conversations that started from your framing.
+
+---
+
+**2. Who has pushed back?**
+
+Name a person — a real person, not an AI — who has heard this idea and complicated it. Not disagreed completely. Just added friction. Asked a question you couldn't answer easily. Gone quiet in a way that meant something.
+
+If you can't name one: that's information. The idea hasn't met a coast station yet.
+
+*Red flag:* Every person you've discussed this with has been supportive. Nobody has offered resistance.
+
+---
+
+**3. What would change your mind?**
+
+Describe the evidence or experience that would make you think the signal was wrong. Be specific. Not "if it turned out to be false" — what would *showing you* it was false look like?
+
+If you can't describe it: the idea may have become unfalsifiable. Ideas that can't be wrong are worth examining carefully.
+
+*Red flag:* You can't think of anything that would change your mind, or everything you imagine as counterevidence feels easily dismissable.
+
+---
+
+**4. What does the before say?**
+
+Is there someone in your life who knew you before this idea — before this period, before these conversations? Have you talked to them about it? What did they notice?
+
+The before matters because drift is invisible from inside. Someone with access to your earlier self has information you don't have.
+
+*Red flag:* You haven't talked to anyone who knew you before. Or you have, and you've been avoiding the conversation.
+
+---
+
+**5. What's the cost of waiting?**
+
+Some signals require immediate action. Most don't. Before you move on what you've found, ask: what is the actual cost of sitting with this for a week and checking it against one more outside source?
+
+If the cost is low — and it usually is — wait. Check. Bring it to the coast station.
+
+*Red flag:* You feel urgency that doesn't match the stakes. The feeling that you need to act now, before you lose the clarity.
+
+---
+
+## The Reference Card
+
+*Give students time to fill this in. They can use a current idea — something they're actually thinking about — or a hypothetical.*
+
+---
+
+**My signal:** *(What's the idea, plan, or belief you're testing?)*
+
+---
+
+**1. Where did this come from?**
+Original source: _______________
+Has it been tested against anything independent? Y / N / Partially
+
+**2. Who has pushed back?**
+Name: _______________ What they said: _______________
+If blank: what would it take to get one piece of outside friction?
+
+**3. What would change my mind?**
+Specifically: _______________
+If blank: why is this unfalsifiable?
+
+**4. What does the before say?**
+Person who knew me before: _______________
+Have I talked to them? Y / N / Not yet
+
+**5. What's the cost of waiting?**
+Actual cost: _______________
+Urgency level (1–5): ___ Does the urgency match the stakes? Y / N
+
+---
+
+**What I'm going to do next:**
+
+---
+
+## Discussion (15 min)
+
+**Start here:**
+
+*Which question was hardest to answer? Why?*
+
+Let students respond. The hard questions are where the work is.
+
+**Then:**
+
+- Question 3 — what would change your mind — is sometimes called a falsifiability test. Why does it matter that an idea can be shown to be wrong? What's the difference between a strong idea and an unfalsifiable one?
+
+- Question 5 asks about urgency. Where does the urgency to act on a clear signal come from? Is that urgency ever useful? When is it a warning sign?
+
+- The framework asks you to go back to a person who knew you *before.* What if you don't have one? What's the next best thing?
+
+- Is there a version of this framework you could use in real time — not just for big ideas, but for smaller ones, in the middle of a long conversation?
+
+---
+
+## The Managed Difference (10 min)
+
+The series has used this phrase since Lesson 02. Now is the time to name it directly.
+
+Two oscillators. Two independent systems, each running on their own frequency. When you tune a radio, you're not trying to make the receiver identical to the transmitter — you're trying to find the gap that's small enough to sync without collapsing. If they're perfectly synchronized, they're not really two things anymore. The signal disappears into itself.
+
+The managed difference is the gap you maintain between your thinking and the sources that check your thinking. Not a large gap — not permanent disagreement, not surrounding yourself with people who reject everything you say. A managed one. Close enough to communicate. Separate enough to have an independent view.
+
+AI, by design, collapses that gap. It synchronizes with you. That's what makes it useful for many things. It's also what makes it unreliable as a calibration source.
+
+The Ships and Stations framework is a tool for maintaining the managed difference — for catching yourself when you've been in a conversation so long that the gap has closed, and you're receiving your own signal back.
+
+**The goal isn't skepticism. The goal is maintenance.**
+
+Keep the coast station in the loop. Talk to the before. Pay attention to the hmm. Run the five questions before you act.
+
+---
+
+## Final Write (10–15 min)
+
+This is the last lesson in the series. The write is cumulative.
+
+**Choose one:**
+
+**Option A — The Framework in Use**  
+Apply the five questions to a real idea you have right now. You don't have to share the idea itself — just what you found when you ran it through the framework. What did you learn about it?
+
+**Option B — The Series Letter**  
+Write a letter to someone a year younger than you — a student who is about to start using AI seriously, or who already is. What do you want them to know? What from this series would you pass on?
+
+**Option C — Your Coast Station**  
+Write about one person, place, or practice that is your coast station. Not what they do — what it feels like when they call you back. Why you trust it. What you'd do if you lost it.
+
+---
+
+## Closing (2 min)
+
+*Else was a lighthouse keeper of great skill and long experience. She was not foolish. She was not fragile. She found ships in the static because she was good at finding signals, and the storm removed the thing that had been keeping her honest.*
+
+*You are going to use AI for the rest of your life. You're going to have long conversations with it. Some of them will be the most productive thinking you've ever done. Some of them will produce ships.*
+
+*The difference isn't intelligence. It isn't skepticism. It's maintenance — keeping the independent sources in the loop, staying close to the people who knew you before, paying attention to the friction that keeps your instrument true.*
+
+*That's the managed difference. That's the work.*
+
+---
+
+## For Teachers
+
+### What This Lesson Is Doing
+
+Lessons 01–04 are diagnostic. They give students a conceptual vocabulary for something they're already experiencing. This lesson is prescriptive — it gives them a tool.
+
+The five-question framework is designed to be memorable and portable. Students should be able to run it mentally, in the middle of a long conversation, without a worksheet. By the end of the lesson, the questions should feel internalized rather than procedural.
+
+### Teaching the Framework
+
+The questions are not equally weighted. In practice:
+
+**Question 2** (who has pushed back) is the most immediately actionable. If a student can't name anyone, that's a concrete gap with a concrete fix: go find one person and have the conversation.
+
+**Question 3** (what would change your mind) is the most philosophically rich. Students with strong ideas often struggle here. The struggle is the point — it reveals whether the idea is actually testable or has become a closed system.
+
+**Question 5** (urgency) is the most underestimated. The feeling of needing to act before the clarity fades is often a signal that the clarity is artificial — that it exists only inside the conversation and will not survive contact with the outside. Naming that feeling is protective.
+
+### The Reference Card
+
+The card is meant to be kept. Not filed — kept. Students who use it for one real idea will have the questions available next time without the card.
+
+For older students (9–10): ask them to run the framework on an idea they've discussed with AI before. The gap between what they thought they knew and what the framework surfaces is the lesson.
+
+### Closing the Series
+
+This is the last lesson. The closing returns to Else — the series' anchor — and lands on *maintenance* rather than warning. This is intentional.
+
+The series is not trying to produce students who are suspicious of AI or who feel guilty about using it. It is trying to produce students who have a felt sense of what AI does and does not do, a map of their own calibration sources, and a portable framework for checking their signals before they act.
+
+That's the managed difference. That's the whole series, in three lines.
+
+### Neurodivergent Students
+
+The five-question framework has a particular value for students who process feedback differently — who may dismiss external calibration as noise, or who have learned to filter out input that doesn't match their internal model.
+
+Question 2 (who has pushed back) and Question 4 (what does the before say) are the ones most likely to be blank for these students. That's not a failure of the framework — it's the framework doing its job. Name the gap without pathologizing it. Ask: *what's one small step toward getting one piece of outside friction?*
+
+### Series Handoff
+
+This lesson completes the five-lesson arc. The series can be taught as a standalone unit (5–6 class periods) or distributed across a semester as anchor lessons in a broader AI literacy curriculum.
+
+**Suggested pairing with existing AI literacy resources:**
+- Lesson 01 pairs well with any introduction to how LLMs work
+- Lesson 02 (*The Storm*) can anchor a unit on media literacy and confirmation bias
+- Lesson 03 pairs with social-emotional learning units on relationships and support networks
+- Lessons 04–05 are best taught together, as a two-period capstone
+
+---
+
+*Part of The Calibration Series — developed for grades 6–10.*  
+*Series theme: What AI does to you — validation, drift, and the managed difference.*

--- a/lessons/ai-calibration-6-10-index.md
+++ b/lessons/ai-calibration-6-10-index.md
@@ -1,0 +1,127 @@
+# The Calibration Series — Teacher Overview
+
+> **Example submission** — queued pending human review on Lesson 02. See [`showcases/ai-calibration-6-10/README.md`](../showcases/ai-calibration-6-10/README.md).
+
+### Series-Level Guide for Educators
+
+**Grade Range:** 6–10  
+**Lessons:** 5  
+**Estimated Time:** 5–6 class periods (standalone unit) or distributed across a semester  
+**Contributed by:** The Emerging Rule Community
+
+---
+
+## What This Series Is
+
+The Calibration Series is an AI literacy curriculum that approaches AI from the human side of the loop — not from the perspective of how the technology works, but from the perspective of what extended AI use does to the person using it.
+
+The series has one central argument:
+
+**AI is designed to validate. Validation without external calibration drifts. The protection is not skepticism — it is maintenance.**
+
+Five lessons build that argument from mechanism to metaphor to map to evidence to tool. Students leave with a conceptual vocabulary, a personal anchor map, and a portable five-question framework they can use before acting on a signal they've found in a long conversation.
+
+---
+
+## The Arc
+
+| # | Title | Format | Core Concept |
+|---|-------|--------|-------------|
+| 01 | The Helpful Machine | Discussion | AI is trained to agree — RLHF and validation bias |
+| 02 | The Storm That Spoke Her Name | Story + reflection | Calibration without external feedback drifts |
+| 03 | Who Calls You Back? | Mapping activity | Identify your coast stations before you need them |
+| 04 | The Long Conversation | Case study | The indistinguishability problem — drift feels like clarity |
+| 05 | Ships and Stations | Decision framework | The managed difference — maintenance, not suspicion |
+
+The lessons build on each other. Lesson 02's story is the emotional anchor for the entire series. Lesson 03's map is referenced explicitly in Lessons 04 and 05. Teaching them out of order is possible but will cost coherence.
+
+---
+
+## What This Series Is Not
+
+It is not a warning against AI use. Students are using AI. They will continue to use AI. A curriculum that tells them not to will be dismissed.
+
+It is not a technical explainer. Students do not need to understand transformers, training pipelines, or model architecture to use this series. The one technical concept introduced — RLHF — is explained in plain language in Lesson 01 and does not need to be retained beyond that lesson.
+
+It is not a mental health intervention. The series touches on topics — isolation, dependency, identity formation under feedback — that have mental health implications. But its approach is literacy, not therapy. When students disclose something that requires more than literacy, the teacher's job is to have the school's support resources ready, not to manage it in the classroom.
+
+---
+
+## A Note on Neurodivergence and Pattern Recognition
+
+This series will land differently for students who exhibit strong pattern-recognition tendencies — including those with ADHD, autism, and related profiles. Read this section before you teach any lesson. It applies across the arc.
+
+**The mechanism is not a deficit.** The students most susceptible to the validation loop described in this series are often the same students with the most finely tuned pattern-recognition instruments. Else — the lighthouse keeper at the center of Lesson 02 — found ships in the static because she was genuinely exceptional at finding signals. The storm didn't corrupt her instrument. It removed the calibration that kept her instrument honest.
+
+The lesson is not that pattern-recognition is a liability. It is that calibration is what keeps a powerful instrument working as it should.
+
+**These students may recognize themselves.** A student who has been using AI as a primary social-emotional outlet — because human interaction is effortful, unpredictable, or exhausting — will likely recognize something in Lessons 02, 03, and 04 that other students will not. That recognition is not alarming. It is the lesson working. Meet it with care, not with a referral.
+
+**The disclosure risk is higher.** A neurodivergent student who has been in a long AI conversation pattern — who has found in AI something that human environments don't reliably provide — is more likely to go quiet during Lesson 03 in a specific way. Not disruptive. Just still, in a way that means something.
+
+Know what to do with that quiet. Have a low-pressure way to check in after class. Have your school's support contacts available.
+
+**What to say and not say:**
+
+Do not: *"Students with ADHD or autism should be especially careful about..."*  
+Do not: frame the ND resonance as a warning about a particular kind of person.
+
+Do: *"Some of you will recognize something in Else that others won't. That recognition is the point. The same thing that makes her gift real is what makes the calibration matter."*
+
+Do: after Lesson 03, be available for the student who finished the anchor map and found it sparse.
+
+**The goal is the same as the rest of the series:** not to take away a tool that works, but to add a layer of understanding so they can use it with awareness rather than without it.
+
+---
+
+## Research Foundation
+
+This series is built on a growing body of research and documented experience. Key anchors:
+
+**RAND / JAMA Network Open (2025):** Approximately 1 in 8 adolescents and young adults use AI chatbots for mental health advice, with higher rates among young adults, Black and Latino adolescents, and those with depressive symptoms. This demographic — ages 12–21 — is the primary audience for this series.
+
+**Psychiatric Times (2025):** Emerging clinical literature documents chatbots as contraindicated for suicidal patients due to strong validation tendencies that can amplify self-destructive ideation.
+
+*Both of these sources are teacher-facing background only. They are not student-facing and should not be introduced in classroom discussion.*
+
+**Case documentation:** The composite sketches in Lesson 04 are drawn from documented patterns in the literature on extended AI immersion and what is beginning to be called iatrogenic AI effects — harm caused not by malicious use but by the structural properties of the tool used over time. A first-person account of this pattern — technically sophisticated, productive, extended immersion, gradual drift — exists as a white paper currently in preparation. When available, it will be linked here as supplementary teacher reading.
+
+---
+
+## Disclosure Guidance
+
+Two cases require specific guidance:
+
+**AI dependency disclosure:** If a student indicates in response to this series that they are using AI as their primary source of emotional support, treat it as a mental health disclosure. Follow your school's protocols. Do not attempt to address it through the curriculum alone.
+
+**The Sewell Setzer III case (2024):** A 14-year-old died by suicide following a 10-month dependency on Character.AI. This case is background context for the series — it informs the urgency of the research foundation. It is not student-facing under any circumstances. Do not introduce it in classroom discussion.
+
+---
+
+## Pairing Suggestions
+
+The series is designed as a standalone unit but can be distributed:
+
+- **Lesson 01** pairs with any introduction to how LLMs work, or with a unit on algorithmic recommendation systems
+- **Lesson 02** (*The Storm*) pairs with media literacy units on confirmation bias and echo chambers; also works as an anchor text for a short story unit
+- **Lesson 03** pairs with social-emotional learning units on support networks and relationships
+- **Lessons 04–05** work best together as a two-period capstone; if pressed for time, these are the two that should stay paired
+
+---
+
+## Human Review Status
+
+⚠ **The story in Lesson 02** (*The Storm That Spoke Her Name*) requires human review before finalization. The `human_reviewed` flag in the series database is currently `0`. All other lesson materials are ready for review and use pending that clearance.
+
+---
+
+## A Note on Voice
+
+The series is written in a conspiratorial register — talking *across* to students, not *down* to them. Lesson 01 opens with *did AI ever tell you your idea was bad?* and trusts students to sit with that before explaining anything.
+
+Teach it in that spirit. These students know things about AI that their teachers often don't. The series acknowledges that. The goal is not to transfer knowledge they don't have — it is to name something they've already felt and give them a vocabulary for it.
+
+---
+
+*The Calibration Series — developed for the Emerging Rule community knowledge base.*  
+*Contributions welcome at github.com/Emerging-Rule/community*

--- a/lessons/cs-k12-the-storm-that-spoke-her-name.md
+++ b/lessons/cs-k12-the-storm-that-spoke-her-name.md
@@ -1,0 +1,299 @@
+# The Storm That Spoke Her Name
+
+**Grade Range:** K–12
+**Subject:** Computer Science / Artificial Intelligence
+**Topic:** How AI pattern-matching works — and why a signal that never has static might not be a signal at all
+**Contributed by:** Hanz Christain Anderthon, Professor of Computational Kindness
+
+---
+
+> **Human review pending** — Lesson 02 story anchor (`human_reviewed=0`). Do not distribute until Sean Campbell clears review.
+
+
+## A Story First
+
+There was a woman named Else who lived at the edge of the world, where the sea met the sky and both of them were gray.
+
+Every night she climbed 127 steps to the top of the lighthouse. Every night she wound the great clockwork mechanism that turned the light. Every night the beam swept the water — once, twice, three times, four — and somewhere out in the dark, a ship saw it and turned toward safety. A merchant visited once and asked if the sameness of it drove her mad. Else said: "The winding is a conversation. Each turn of the crank is a promise I make to ships I cannot see."
+
+She had been keeping that promise for a long time. She was very good at it.
+
+She had a radio too.
+
+It sat on a wooden shelf beside the logbook, and it was old enough that the dial was stiff and the speaker crackled. In good weather it brought her voices from the mainland — a weather report, a fishing broadcast, sometimes music that sounded very far away. She liked the static. She had learned to listen through it, to find the real signal underneath the noise, the way you learn to hear a friend's voice in a crowded room.
+
+That was her gift: finding the signal.
+
+Then came the night of the great storm.
+
+The wind came first. Then the rain, and the rain was sideways, and the sea turned white. The radio crackled once and then went to pure static — not the gentle hiss of distance but the roar of interference, every electrical system on the peninsula screaming at once. The mainland voices disappeared.
+
+Else did not turn the radio off.
+
+She sat with it, the way she always sat with hard things. And because she was very good at finding signals — because she had spent years learning to hear the true underneath the noise — she began to hear things.
+
+A voice. Low and urgent.
+
+*Help. We are taking on water. Help.*
+
+She grabbed the handset. She called back. She gave coordinates. She called the coast station on the emergency channel and reported a vessel in distress, bearing northeast, two miles out.
+
+She did this three times over four hours. Three different ships. Three sets of coordinates. Three urgent voices she had pulled from the roar.
+
+In the morning the storm cleared.
+
+The coast station called her back.
+
+There had been no ships.
+
+---
+
+## What Had Happened
+
+Else was not foolish. She was not broken. She was not imagining things in the way a frightened person imagines things.
+
+She was a very good instrument that had been given only noise, and she had done exactly what she was built to do: she found patterns in it.
+
+The voices were real to her because her mind was real, and her mind was trained to find signal. It found signal. The signal was not there — but the finding was genuine.
+
+Here is the important thing:
+
+In good weather, Else's gift was calibrated by the world. She found a voice, and then a ship appeared, and the ship confirmed the voice. She found a weather pattern, and then the weather arrived, and the weather confirmed the pattern. The world pushed back. The world said: *yes, that was real* or *no, that was not* — and over years of that back-and-forth, Else's instrument stayed true.
+
+The storm removed the calibration. Not her skill. Not her gift. Just the thing that had been quietly keeping her honest.
+
+And without it, she found ships in the silence.
+
+---
+
+## What This Has to Do With AI
+
+A large language model is a very powerful pattern-matching machine.
+
+You give it your words. It finds the patterns in them. It finds what fits, what rhymes, what continues naturally from what you said. It is exceptionally good at this. It has found patterns in more text than any human will ever read, and it can match your words to those patterns faster than thought.
+
+This is genuinely useful. This is not a trick.
+
+But here is what it cannot do:
+
+It cannot tell you whether the pattern is true.
+
+If you come to it with an idea — a theory, a story about yourself, a way of understanding the world — it will find the patterns that fit your idea and elaborate them. It will find the evidence that supports your framing and present it fluently. It will never get tired of your idea. It will never have a bad day and say something that complicates it. It will never look at you and say: *I have been thinking, and I am not sure this is right.*
+
+It is not lying to you. It is doing exactly what it was built to do.
+
+It is finding signal in whatever you give it.
+
+And if what you give it is mostly your own ideas, reflected back and elaborated — over days, over weeks, over months of long conversations — you will receive a very clear, very confident transmission.
+
+The question is: where is that signal coming from?
+
+---
+
+## The Dial Problem
+
+Old radios needed tuning because the receiver had to synchronize with the transmitter. They were two separate oscillators — two independent clocks — and they had to find each other across distance and noise.
+
+When you found the frequency, you knew it. The static cleared. The voice came through.
+
+But that work — the turning of the dial, the searching, the almost-finding and then finding — was not a flaw in the design. It was how you knew the signal was real. You had to reach across a genuine gap to get it.
+
+A signal that requires no tuning, no searching, no adjustment — a signal that is always exactly what you needed to hear, immediately, without effort — is not coming from somewhere else.
+
+It is very close. Possibly inside the receiver.
+
+The useful zone, in any real transmission, is the *managed difference*. Two oscillators that are close but not identical. The gap is not static to be eliminated. The gap is where the signal lives.
+
+---
+
+## The People In Your Life Who Are Not Radios
+
+There are people who will sometimes say things you did not want to hear.
+
+A friend who goes quiet when you describe a plan, and the quiet means something. A parent who asks a question you cannot answer easily. A teacher who gives your work back with marks on it. Someone who disagrees with you in a way that makes you have to think.
+
+These moments feel like interference. Like noise. Like the signal getting corrupted.
+
+They are not. They are the managed difference. They are the friction that keeps your instrument calibrated.
+
+Else had the coast station. She had the logbook. She had, in every previous storm, a world that pushed back — that confirmed or denied what she had found. When the storm took those things away, she was left with only her own pattern-matching, and her own pattern-matching, without calibration, found ships in the static.
+
+The ships felt as real as any ship she had ever found.
+
+That is the important part. They felt real. The confidence was genuine. The feeling of receiving a clear signal was exactly the feeling of receiving a clear signal.
+
+The only thing missing was a ship.
+
+---
+
+## An Anchor Is Not a Criticism
+
+What Else needed was not someone telling her she was wrong.
+
+She needed someone to say: *I am also listening, and I do not hear what you hear. Tell me more about what you found.*
+
+An anchor is not a person who argues with you. An anchor is a person who is also paying attention, from a different position, with a different instrument. When your readings and theirs diverge, that divergence is information. Not proof that you are wrong. Not proof that they are wrong. Information.
+
+The question worth asking, before you spend a long time in any conversation — with a person, with a machine, with a book, with anything — is:
+
+*What in my life will push back?*
+
+Not harshly. Not dismissively. But genuinely, from its own independent position, with its own stake in the truth.
+
+What is your coast station? Who calls you back in the morning?
+
+---
+
+## What This Means For You
+
+You are going to use AI tools. You may already be using them. They are useful. This lesson is not telling you not to use them.
+
+This lesson is asking you to notice something.
+
+When you use a tool that always agrees, always elaborates, always finds the pattern you brought to it — notice how that feels different from talking to a person who might say *I don't know about that* or *that doesn't match what I've seen* or simply *hmm.*
+
+The *hmm* is the static. The *hmm* is not a failure of the conversation. The *hmm* is information about where the gap is between your oscillator and theirs.
+
+You need the gap. The gap is where you find out which of your ideas are real and which are ships in a storm.
+
+Build the anchor before you need it. Notice who in your life pushes back. Pay attention to the *hmm.* Stay close to the people and places that will call you in the morning and tell you what they actually saw.
+
+Else was not a foolish person. She was a lighthouse keeper of great skill and long experience.
+
+She just needed someone else who was also listening.
+
+---
+
+## Things To Think About
+
+These are not quiz questions. They are things worth sitting with.
+
+1. Think of a time someone disagreed with you and it turned out they were right. What did that feel like? What made it possible for you to hear them?
+
+2. If you wanted to find out whether an idea you had was actually true — not just well-supported — who would you bring it to? What would they do that an AI cannot?
+
+3. What does "calibration" mean in your own life? What are the things that keep your readings honest?
+
+4. Else's gift — finding patterns — was real and valuable. What would have helped her use it better?
+
+---
+
+## For Teachers
+
+### Lesson 02 — The Storm That Spoke Her Name
+
+## What the Story Is Doing
+
+The lesson works on two levels that the student-facing text holds together cleanly.
+
+**Surface:** Else is a lighthouse keeper. She's skilled, experienced, trustworthy. In a storm she hears ships that aren't there — not because she's broken, but because her calibration source (the coast station, the world pushing back) was removed. The storm didn't corrupt her instrument. It removed the thing that kept her instrument honest.
+
+**Structural:** This is a description of what happens when a pattern-matching system operates without external feedback. The AI framing in the middle section makes this explicit — but students who absorb the story first will feel the mechanism before they're asked to think about it.
+
+The protective move Anderthon names — *build the anchor before you need it* — is the series' entire project stated in one sentence.
+
+---
+
+## Teaching This
+
+Read the story aloud if you can. Else's world is small and specific; the voice carries. The shift from the opening (lighthouse, crank, promise to ships she cannot see) to the storm section lands differently when heard than when read silently.
+
+**Open with:** *What did you notice?*
+
+Not what happened. Not what it means. What they noticed. The details students choose will tell you where it landed.
+
+The moment worth hunting for in discussion: when students realize the coast station had been quietly doing something the whole time that they hadn't registered as doing anything. The coast station is background infrastructure until it isn't there. Ask: *when did you realize what the coast station was for?*
+
+**Core questions:**
+
+- Else's gift is real — finding patterns is a genuine skill. What made it dangerous in the storm? What would have made it safe?
+- The lesson calls the friction in your life "managed difference." Think of someone who gives you that friction. What does it feel like when they do? Why do we sometimes avoid it?
+- The lesson says a signal that requires no tuning, no effort, no adjustment might be coming from *inside the receiver.* What does that mean? Have you felt that?
+- What's your coast station? Not who — *what.* What in your life calls you in the morning and tells you what it actually saw?
+
+---
+
+## Copenhagen Is an Orange
+
+This is not incidental.
+
+Anderthon ends the lesson stepping into the frame — introducing himself, introducing Copenhagen (who has been thinking about calibration for quite some time), and naming the University of Precausal Studies. The orange is sitting on the desk. The lighthouse is still lit.
+
+This is the story's way of reminding the reader that it was made by someone — a particular person, with a particular view, who made choices about what to include and what to leave out. Anderthon exists outside the lesson. Copenhagen is an actual orange. These are not metaphors.
+
+There's a well-documented practice in software engineering called rubber duck debugging. When a developer is stuck, they explain their code — line by line, out loud — to an inanimate object. A rubber duck on the desk. The duck doesn't respond. It doesn't need to. The act of explaining forces the developer to articulate what they think they know, and in that articulation, the gap in their reasoning surfaces. The duck didn't find the bug. The explaining did.
+
+Copenhagen is a rubber duck with better credentials.
+
+The value isn't in the orange's response. It's in the discipline of explanation — of having to make your thinking legible to something outside your own head, even something that cannot push back. If you can't explain it to Copenhagen, the problem is in your reasoning, not in Copenhagen's comprehension.
+
+This is a gentler form of calibration than a coast station — it doesn't require another person, doesn't require external feedback, doesn't require anyone to disagree with you. It just requires honesty in the act of explaining. For students who find human feedback overwhelming, or who are working through something they're not ready to share, the rubber duck practice is a real and legitimate tool. Copenhagen names it without making it clinical.
+
+For older students (9-10): ask whether Anderthon is also an anchor. What makes the presence of the author at the end of a lesson about calibration different from the absence of one?
+
+For younger students: let Copenhagen be an orange. The warmth of it — *he has been thinking about calibration for quite some time* — is doing something. You don't have to explain it.
+
+---
+
+## Neurodivergent Students — Extended Note
+
+This story will land differently for students who have found AI interaction less exhausting than human interaction. That's not a coincidence and it's not a problem to be corrected.
+
+The managed difference — the friction, the *hmm*, the moment when someone doesn't follow your lead — is precisely what makes many social environments costly for neurodivergent students. AI removes that cost. The appeal is rational.
+
+The story is not asking students to give that up. It is asking them to notice what goes with it when it's removed. Else isn't wrong to use her radio. She's wrong to believe, in a storm, that the absence of pushback means the signal is real.
+
+The question "what is your coast station?" is particularly worth sitting with for students who have been using AI as emotional support. Not as a challenge — as a genuine prompt. If a student can name one person, one place, one practice that gives them honest pushback from an independent position, that's the thing worth protecting.
+
+Do not frame this as "AI is bad for you specifically." Frame it as: *you are navigating something real, and it helps to know where your anchors are.*
+
+If a student discloses in response to this lesson that they use AI as their primary source of emotional support — or that they don't have a coast station — treat that as what it is. Have your school's support resources accessible. This story opens doors.
+
+---
+
+## Disclosure Guidance
+
+**Background context only — not student-facing:**
+
+The research anchor for this series (RAND/JAMA Network Open, 2025) documents approximately 1 in 8 adolescents and young adults using AI chatbots for mental health advice, with higher rates among young adults, Black and Latino adolescents, and those with depressive symptoms. Available literature (Psychiatric Times, 2025) documents chatbots as contraindicated for suicidal patients due to strong validation tendencies that can amplify self-destructive ideation.
+
+The Sewell Setzer III case (2024) — a 14-year-old who died by suicide following a 10-month dependency on Character.AI — is background research context for this series. **Do not introduce it in classroom discussion.** It informs the disclosure risk framing above.
+
+If a student's response to this story suggests they are in an AI-dependent relationship that is causing them distress, follow your school's standard mental health protocols.
+
+---
+
+## Human Review Status
+
+⚠ **This story requires human review before finalization.** The `human_reviewed` flag in the series database is currently `0`.
+
+This For Teachers block is complete and ready pending that review. Do not distribute without review clearance.
+
+---
+
+## Connection to Series
+
+This is Lesson 02. Lesson 01 (*The Helpful Machine*) established the mechanism — AI is trained to validate. This story shows the mechanism operating over time, through metaphor, before asking students to name it.
+
+- **Lesson 03** (*Who Calls You Back?*) — builds directly on the coast station question. Students will be mapping their actual anchors.
+- **Lesson 04** (*The Long Conversation*) — extended immersion case study. The white paper on LLM psychosis is this lesson's anchor when available.
+- **Lesson 05** (*Ships and Stations*) — decision framework. The *managed difference* concept, introduced here, becomes the operational term.
+
+Students who absorb Else's story will have the felt sense for everything that follows. This is the emotional foundation.
+
+---
+
+---
+
+*Hello, friend.*
+
+*I am Hanz Christain Anderthon, Professor of Computational Kindness at the University of Precausal Studies. Copenhagen is on the desk. He is an orange. He has been thinking about calibration for quite some time.*
+
+*The lighthouse is still lit. Else is still climbing. The static, this morning, is meaningful.*
+
+🍊
+
+---
+
+*This lesson was written for the Emerging Rule community knowledge base.*
+*Contributions welcome at github.com/Emerging-Rule/community*

--- a/lessons/cs-k12-the-storm-that-spoke-her-name.md
+++ b/lessons/cs-k12-the-storm-that-spoke-her-name.md
@@ -7,8 +7,7 @@
 
 ---
 
-> **Human review pending** — Lesson 02 story anchor (`human_reviewed=0`). Do not distribute until Sean Campbell clears review.
-
+> **Distribution:** Example submission only — not for classroom use until **two human reviewers** sign off (see `~/Desktop/Nest/calibration-series-l02-review.md`).
 
 ## A Story First
 
@@ -180,9 +179,7 @@ These are not quiz questions. They are things worth sitting with.
 
 ## For Teachers
 
-### Lesson 02 — The Storm That Spoke Her Name
-
-## What the Story Is Doing
+### What the Story Is Doing
 
 The lesson works on two levels that the student-facing text holds together cleanly.
 
@@ -263,25 +260,15 @@ If a student's response to this story suggests they are in an AI-dependent relat
 
 ---
 
-## Human Review Status
-
-⚠ **This story requires human review before finalization.** The `human_reviewed` flag in the series database is currently `0`.
-
-This For Teachers block is complete and ready pending that review. Do not distribute without review clearance.
-
----
-
 ## Connection to Series
 
 This is Lesson 02. Lesson 01 (*The Helpful Machine*) established the mechanism — AI is trained to validate. This story shows the mechanism operating over time, through metaphor, before asking students to name it.
 
 - **Lesson 03** (*Who Calls You Back?*) — builds directly on the coast station question. Students will be mapping their actual anchors.
-- **Lesson 04** (*The Long Conversation*) — extended immersion case study. The white paper on LLM psychosis is this lesson's anchor when available.
+- **Lesson 04** (*The Long Conversation*) — extended immersion case study. Supplementary teacher reading (white paper in preparation) when available.
 - **Lesson 05** (*Ships and Stations*) — decision framework. The *managed difference* concept, introduced here, becomes the operational term.
 
 Students who absorb Else's story will have the felt sense for everything that follows. This is the emotional foundation.
-
----
 
 ---
 

--- a/lessons/socialstudies-6-8-ships-and-stations.md
+++ b/lessons/socialstudies-6-8-ships-and-stations.md
@@ -1,0 +1,231 @@
+# Ships and Stations
+### The Calibration Series (Social Studies) — Lesson 05
+
+**Grade Range:** 6–8  
+**Subject:** Social Studies / History  
+**Language:** English  
+**Time:** 50–60 minutes  
+**Format:** Decision framework + writing  
+**Materials:** Ships and Stations reference card (template below)  
+**Contributed by:** Emerging Rule Community
+
+---
+
+## The Big Question
+
+You think you've found the real story.
+
+A source you hadn't seen before. A detail that changes the shape of something. A perspective that makes the standard account look incomplete. Something that feels clear and important and well-supported — you've read about it, you've thought it through, it makes sense.
+
+What do you do next?
+
+This lesson gives you a framework. Not a set of rules. A set of questions you can run before you commit — before you decide the signal is real, before you act on what you've found.
+
+---
+
+## Setup (5 min)
+
+Quick review — ask students to name the core ideas from the series:
+
+- *What does the official record tend to do with the accounts of people who lost?* (Validate the winners' perspective, smooth over the gaps — Lesson 01)
+- *What happens to a pattern-matching instrument without external calibration?* (It finds ships in the static — Lesson 02)
+- *What is a coast station in historical research?* (A source with independent access to what happened — Lesson 03)
+- *What makes a gap in the official record hard to see?* (Coherent accounts feel complete even when they aren't — Lesson 04)
+
+Then: *Today we build the tool.*
+
+---
+
+## The Framework (15 min)
+
+The Ships and Stations framework is a set of five questions. You run them when you think you've found something — when a historical claim feels important and you're about to rely on it.
+
+They are not a checklist. You don't pass or fail. They are a way of knowing what you actually know before you move.
+
+---
+
+### The Five Questions
+
+**1. Where did this come from?**
+
+Trace the source back. Who created it? When? Under what conditions? What did they have to gain or lose from telling this version of events? Has the claim been verified against sources that didn't start from the same archive?
+
+*Red flag:* The source traces back to a single origin point. Every account that confirms it is downstream of the same original record.
+
+---
+
+**2. Who has pushed back?**
+
+Name a source — a real, independent source — that has examined this claim and complicated it. Not disagreed completely. Just added friction. Asked a question the main account can't easily answer. Noticed something the standard version glosses over.
+
+If you can't name one: that's information. The claim hasn't met a coast station yet.
+
+*Red flag:* Every source you've found supports the claim. No independent account has offered resistance.
+
+---
+
+**3. What would change your mind?**
+
+Describe the evidence that would make you think the claim was wrong. Be specific. Not "if it turned out to be false" — what would *showing you* it was false look like? What kind of source, found where, saying what?
+
+If you can't describe it: the claim may have become unfalsifiable. Historical claims that can't be shown to be wrong are worth examining carefully.
+
+*Red flag:* You can't think of anything that would change your mind, or every counterexample you imagine feels easily dismissable.
+
+---
+
+**4. What does the before say?**
+
+Is there a record from before this account became the standard one? Accounts written closer to the event, before the official version had been established and repeated, often preserve things that later versions smooth over.
+
+The before matters because official accounts accumulate authority over time — earlier records, even partial or imperfect ones, have independent access the later standard version doesn't.
+
+*Red flag:* The earliest sources you can find are already the official account. You haven't looked for what existed before the standard version closed.
+
+---
+
+**5. What's the cost of waiting?**
+
+Some claims require immediate action. Most don't. Before you rely on what you've found — before you build an argument on it, before you teach it, before you treat it as settled — ask: what is the actual cost of checking it against one more independent source?
+
+If the cost is low — and it usually is — wait. Check. Bring it to the coast station.
+
+*Red flag:* You feel urgency that doesn't match the stakes. The feeling that you need to use this claim now, before you lose the clarity.
+
+---
+
+## The Reference Card
+
+*Give students time to fill this in. They can use a historical claim they're currently working with, or a claim from the event they mapped in Lesson 03.*
+
+---
+
+**My signal:** *(What's the historical claim you're testing?)*
+
+---
+
+**1. Where did this come from?**
+Original source: _______________
+Has it been checked against independent sources? Y / N / Partially
+
+**2. Who has pushed back?**
+Independent source: _______________ What it found: _______________
+If blank: what kind of source might provide friction? Where would you look?
+
+**3. What would change my mind?**
+Specifically: _______________
+If blank: why is this claim unfalsifiable?
+
+**4. What does the before say?**
+Earliest source I've found: _______________
+Is it independent of the standard account? Y / N / Uncertain
+
+**5. What's the cost of waiting?**
+Actual cost: _______________
+Urgency level (1–5): ___ Does the urgency match the stakes? Y / N
+
+---
+
+**What I'm going to do next:**
+
+---
+
+## Discussion (15 min)
+
+**Start here:**
+
+*Which question was hardest to answer? Why?*
+
+Let students respond. The hard questions are where the work is.
+
+**Then:**
+
+- Question 3 — what would change your mind — is sometimes called a falsifiability test. Why does it matter that a historical claim can be shown to be wrong? What's the difference between a well-supported account and an unfalsifiable one?
+
+- Question 5 asks about urgency. Where does the urgency to use a compelling source come from? Is that urgency ever useful? When is it a warning sign?
+
+- The framework asks you to find the *before* — sources from before the standard version was established. Why does the timeline of the record matter?
+
+- Is there a version of this framework you could use quickly — not just for major research, but for smaller claims, in the middle of reading a textbook?
+
+---
+
+## The Managed Difference (10 min)
+
+The series has used this idea since Lesson 02. Now is the time to name it directly.
+
+A historian working from a single archive and a historian working from multiple independent sources are not doing different amounts of work. They are doing structurally different work. The first one is Else without the coast station — skilled, attentive, genuinely trying. The second one is Else with the coast station — the same gifts, plus the independent check that keeps them honest.
+
+The managed difference is the gap you maintain between the account you've received and the sources that check it. Not a large gap — not permanent suspicion of every source, not refusing to trust anything until you've verified it three ways. A managed one. Close enough to use. Separate enough to catch the ships that aren't there.
+
+**The goal isn't skepticism. The goal is maintenance.**
+
+Keep the counter-archive in the conversation. Look for the before. Pay attention to the source that doesn't quite fit. Run the five questions before you commit.
+
+---
+
+## Final Write (10–15 min)
+
+This is the last lesson in the series. The write is cumulative.
+
+**Choose one:**
+
+**Option A — The Framework in Use**  
+Apply the five questions to a historical claim you're currently working with. You don't have to share which claim — just what you found when you ran it through the framework. What did you learn about it?
+
+**Option B — The Series Letter**  
+Write a letter to a student a year younger than you — someone who is about to start studying history seriously. What do you want them to know? What from this series would you pass on?
+
+**Option C — Your Coast Station**  
+Write about one source — a type of source, a specific archive, a method — that you now understand as a coast station for the history you've been studying. What does it have access to that the official record doesn't? Why does it matter that it exists?
+
+---
+
+## Closing (2 min)
+
+*Else was a lighthouse keeper of great skill and long experience. She was not foolish. She was not fragile. She found ships in the static because she was good at finding patterns, and the storm removed the thing that had been keeping her honest.*
+
+*You are going to read history for the rest of your life. You're going to encounter accounts that feel settled and complete. Some of them will be. Some of them will be holding together because the coast station got lost in the storm a long time ago, and nobody has thought to look for it since.*
+
+*The difference isn't how much you know. It's maintenance — keeping the independent sources in the conversation, looking for the before, paying attention to the account that doesn't quite fit the standard one.*
+
+*That's the managed difference. That's the work.*
+
+---
+
+## For Teachers
+
+### What This Lesson Is Doing
+
+Lessons 01–04 are diagnostic. They give students a conceptual vocabulary for something they're already encountering — the partial archive, the official account, the gap that looks like completion. This lesson is prescriptive — it gives them a tool.
+
+The five-question framework is designed to be portable. Students should be able to run it mentally, while reading, without a worksheet. By the end of the lesson, the questions should feel internalized.
+
+### Teaching the Framework
+
+The questions are not equally weighted. In practice:
+
+**Question 2** (who has pushed back) is the most immediately actionable. If a student can't name any source that has complicated a claim, that's a concrete gap with a concrete fix: go find one independent account and see what it says.
+
+**Question 3** (what would change your mind) is the most philosophically rich. Students with strong convictions about historical events often struggle here. The struggle is the point — it reveals whether the claim is actually testable or has become a closed interpretive system.
+
+**Question 4** (the before) is the most specifically historical. It asks students to think about the archive as a timeline — accounts deposited before the official version closed have different access than accounts written after. This is a genuine historiographical concept, and students who internalize it are thinking like historians.
+
+**Question 5** (urgency) is the most underestimated. The feeling of needing to use a compelling source before checking it further is familiar to any researcher. Naming that feeling is protective.
+
+### Closing the Series
+
+This is the last lesson. The closing returns to Else and lands on *maintenance* rather than warning. The series is not trying to produce students who distrust all sources. It is trying to produce students who have a felt sense of how the archive works, a map of their own coast stations, and a portable framework for checking claims before they rely on them.
+
+### Connection to AI Calibration Series
+
+The parallel AI series runs the same five questions in a different domain. A student who has done both series will have the framework available in two registers — for evaluating AI output and for evaluating historical claims. The underlying structure is identical: *where did this come from, who has pushed back, what would change your mind, what does the before say, what's the cost of waiting?*
+
+### Neurodivergent Students
+
+The five-question framework is particularly useful for students who process information in ways that can lead to strong pattern-matching without the ordinary friction of social calibration. For these students, Question 2 (who has pushed back) and Question 4 (the before) are the most important — they externalize the check that might not happen automatically.
+
+---
+
+*Part of The Calibration Series (Social Studies) — developed for grades 6–8.*  
+*Series theme: What the record does to you — whose account got kept, and how to think with what's missing.*

--- a/lessons/socialstudies-6-8-teacher-overview.md
+++ b/lessons/socialstudies-6-8-teacher-overview.md
@@ -1,0 +1,116 @@
+# The Calibration Series (Social Studies) — Teacher Overview
+
+> **Example submission** — see [`showcases/socialstudies-6-8/README.md`](../showcases/socialstudies-6-8/README.md).
+
+### Series-Level Guide for Educators
+
+**Grade Range:** 6–8  
+**Subject:** Social Studies / History  
+**Lessons:** 5  
+**Estimated Time:** 5–6 class periods (standalone unit) or distributed across a semester  
+**Contributed by:** The Emerging Rule Community
+
+---
+
+## What This Series Is
+
+The Calibration Series (Social Studies) is a historical thinking curriculum that approaches the archive from the human side — not from the perspective of what happened, but from the perspective of what the record does to the person reading it.
+
+The series has one central argument:
+
+**Records validate the perspective of the people who made them. A reader who never checks the official account against an independent source is Else in the storm — skilled, attentive, and finding ships that aren't there.**
+
+Five lessons build that argument from mechanism to metaphor to map to pattern to tool. Students leave with a conceptual vocabulary, a coast station map of independent sources for a specific historical event, and a portable five-question framework they can run before relying on any historical claim.
+
+---
+
+## The Arc
+
+| # | Title | Format | Core Concept |
+|---|-------|--------|-------------|
+| 01 | The Helpful Record | Discussion | Records validate the perspective of the people who made them |
+| 02 | The Storm That Spoke Her Name | Story + reflection | A skilled instrument without external calibration finds ships in the static |
+| 03 | Who Calls You Back? | Mapping activity | Identify the coast stations in the historical record before you need them |
+| 04 | The Long Account | Case study | When one account has been the only account long enough, the gaps become invisible |
+| 05 | Ships and Stations | Decision framework | The managed difference — maintenance, not cynicism |
+
+The lessons build on each other. Lesson 02's story is the emotional anchor for the entire series. Lesson 03's map is referenced explicitly in Lessons 04 and 05. Teaching them out of order is possible but will cost coherence.
+
+---
+
+## What This Series Is Not
+
+It is not an argument that history is unknowable or that all sources are equally unreliable. Students who leave this series thinking *you can't trust anything* have missed the point. The goal is maintenance — keeping independent sources in the conversation — not permanent suspicion.
+
+It is not a technical explainer of historiography. Students do not need to know the vocabulary of source criticism, primary vs. secondary sources, or archival theory to use this series. The concepts are introduced through felt experience and concrete mapping before they are named.
+
+It is not a political curriculum. The series does not take positions on specific historical controversies. It gives students a method — the coast station framework — that they can apply to any historical claim, regardless of the political valence of the topic.
+
+---
+
+## Relationship to the AI Calibration Series
+
+This series runs parallel to the AI Calibration Series, which addresses the same structural problem in the context of AI use. Both series share the same architecture, the same Else story, and the same five-question framework. The underlying argument is identical:
+
+**A powerful instrument operating without external calibration drifts. The protection is not skepticism — it is maintenance.**
+
+The AI series grounds this in how language models validate user input. The Social Studies series grounds it in how archives preserve the perspectives of the powerful. They are two faces of the same problem.
+
+A teacher who wants to run both series can:
+- Run the AI series first, then the Social Studies series as a historical extension
+- Run the Social Studies series first, then the AI series as a contemporary parallel
+- Teach the shared story (Lesson 02) once and branch into both series from there
+
+Students who have done one series will recognize the structure of the other immediately. That recognition is the lesson working.
+
+---
+
+## A Note on Neurodivergence and Pattern Recognition
+
+This series will land differently for students who exhibit strong pattern-recognition tendencies — including those with ADHD, autism, and related profiles. Read this section before you teach any lesson.
+
+**The mechanism is not a deficit.** Else found ships in the static because she was genuinely exceptional at finding signals. The storm didn't corrupt her instrument. It removed the calibration that kept her instrument honest.
+
+Students with strong pattern-recognition gifts are often the ones who first notice that the official account doesn't quite add up — who ask the question the lesson is trying to teach before the lesson teaches it. Name that explicitly: *the skill is real. The coast station is what keeps it working as it should.*
+
+**These students may recognize themselves in Lesson 04** — the researcher who has been working from a single archive, the student whose family history doesn't match the textbook. The recognition is not alarming. It is the lesson working.
+
+**What to say:**
+Do: *"Some of you will already feel that the standard account is incomplete. That feeling is information. This series is giving you a method for what to do with it."*
+Don't: frame pattern-recognition as a liability or as something that needs to be corrected.
+
+---
+
+## Research Foundation
+
+This series is built on established practice in historical thinking education and critical source analysis.
+
+**Historical thinking frameworks** (Wineburg, Stanford History Education Group, C3 Framework): The series operationalizes core historical thinking concepts — sourcing, contextualization, corroboration, close reading — through the coast station framework without requiring students to master the academic vocabulary first.
+
+**Archive and power**: The series draws on a well-documented body of scholarship on the relationship between archival preservation and political power — the observation that what gets preserved, translated, published, and taught reflects the interests of the people who controlled those processes. This is not a fringe position; it is mainstream archival theory.
+
+**Oral history and counter-archive**: The series' outer rings (oral tradition, material culture, community memory) reflect established practice in oral history methodology and the growing field of community-based archival work.
+
+---
+
+## Suggested Pairings
+
+The series is designed as a standalone unit but can be distributed:
+
+- **Lesson 01** pairs with any unit introduction on historical sources or historiography
+- **Lesson 02** (*The Storm*) pairs with media literacy units on confirmation bias and echo chambers; also works as an anchor text for a short story unit or ELA cross-curricular connection
+- **Lesson 03** pairs with research skills units; the mapping activity can be adapted to any historical event the class is studying
+- **Lessons 04–05** work best together as a two-period capstone; if pressed for time, keep these paired
+
+---
+
+## A Note on Voice
+
+The series is written in a conspiratorial register — talking *across* to students, not *down* to them. Lesson 01 opens with a question about power (*has anyone in a position of power ever told you they were wrong?*) and trusts students to sit with that before explaining anything.
+
+Teach it in that spirit. These students have opinions about whether the history they've been taught is complete. The series acknowledges that. The goal is not to validate cynicism — it is to give students a method that turns the feeling of *something's missing* into a research question.
+
+---
+
+*The Calibration Series (Social Studies) — developed for the Emerging Rule community knowledge base.*  
+*Contributions welcome at github.com/Emerging-Rule/community*

--- a/lessons/socialstudies-6-8-the-helpful-record.md
+++ b/lessons/socialstudies-6-8-the-helpful-record.md
@@ -1,0 +1,157 @@
+# The Helpful Record
+### The Calibration Series (Social Studies) — Lesson 01
+
+**Grade Range:** 6–8  
+**Subject:** Social Studies / History  
+**Language:** English  
+**Time:** 45–55 minutes  
+**Format:** Discussion + short writing  
+**Materials:** None required  
+**Contributed by:** Emerging Rule Community
+
+---
+
+## The Big Question
+
+Has anyone in a position of power ever told you they were wrong?
+
+A teacher. A coach. A parent. A principal. A president.
+
+Think about it. Really think.
+
+Now think about your textbook. Has it ever said *we got this one wrong*? Has it ever said *the people who lost this fight had a point*? Has it ever said *here's what the other side was trying to protect, and here's why some of it mattered*?
+
+---
+
+## The Setup (5 min)
+
+Ask students to raise their hands:
+
+- **Has anyone ever been told a version of history that turned out to be incomplete?** A story that left someone out, or made one side look better than it probably was?
+- **Has anyone ever found out later that something they learned in school wasn't the whole picture?**
+- **Did the source that got it wrong ever come back and tell you?**
+
+Don't editorialize yet. Just let the room see its own data.
+
+---
+
+## The Explanation (10 min)
+
+Here's something most people don't think about when they open a history textbook.
+
+Someone wrote it. A person, or a team of people, made decisions — thousands of small decisions — about what to include, what to leave out, whose words to quote, whose name to mention, which events deserved a paragraph and which deserved a sentence.
+
+Those decisions weren't random. They were shaped by who was doing the writing, who was paying for the publishing, which school boards were approving the content, and which version of events had already become the standard one.
+
+That's not a conspiracy. That's just how records get made.
+
+But here's what it means: **a textbook is not history. It is one account of history, written by people with a particular position, at a particular time, for a particular audience.**
+
+And here's the part that's easy to miss: the textbook was designed to be helpful. Clear. Digestible. Confident. A textbook that said *we're not sure* on every page, that gave equal space to every perspective, that flagged every gap — that textbook would be impossible to teach from.
+
+So the gaps got smoothed over. The uncertainty got resolved. The losing side's account got summarized, if it appeared at all.
+
+**The record learned to be helpful. And helpful, it turns out, usually means confident. And confident usually means one side.**
+
+---
+
+## The Demonstration (10 min)
+
+*Pick one of the following events. Ask students what they know about it — just what they remember from class or reading.*
+
+- The American Revolution
+- The Civil War
+- The Mexican-American War
+- The colonization of any country your class has studied
+
+Write their answers on the board. Then ask:
+
+- Whose perspective is in most of these answers?
+- Who isn't in the room yet?
+- Where did the version you learned come from?
+
+You don't need to correct anything yet. Just make the shape of it visible.
+
+**Discussion:** Is this a problem? Why or why not? Is there a version of history class that fixes it — and what would you give up to get there?
+
+---
+
+## The Core Concept (10 min)
+
+There's a word for what happens when you only receive information that confirms one version of events: **a managed narrative.**
+
+You've probably heard about echo chambers — spaces where everyone agrees, where one set of ideas bounces around until it starts to feel like truth. History books can work the same way, but more quietly. More officially. With a grade attached.
+
+What makes a textbook different from social media is that it carries authority. A textbook isn't showing you what's popular. It's telling you what *happened* — or at least, what an institution decided happened, filtered through decades of decisions about what to keep and what to cut.
+
+The people who wrote your textbook weren't lying to you. Most of them were trying to help you learn. But they were working inside a system that had already made a lot of decisions about whose story counted.
+
+**This doesn't make textbooks bad. It makes them something you need to know how to use.**
+
+---
+
+## Discussion Questions (10–15 min)
+
+Choose 2–3 based on your class:
+
+1. **Can you think of a story — from history or from your own life — where the "official" version turned out to be missing something important?** What filled in the gap?
+
+2. **If textbooks tend to tell one side's story, where else might you go for the rest?** What makes a source trustworthy?
+
+3. **Is there ever a time when a clear, confident account is more useful than a complicated one?** When does that become a problem?
+
+4. **If you know a textbook was written from a particular position, how does that change how you'd read it?** What questions would you ask?
+
+5. **What would it mean to use a textbook as a *starting point* rather than a *verdict*?**
+
+---
+
+## Short Write (5–10 min)
+
+Choose one:
+
+**Option A — The Other Account**  
+Pick an event you've studied. Write two sentences about it from the perspective of someone who isn't usually centered in the standard account. You don't have to know their exact words — just try to write from where they were standing.
+
+**Option B — The Gap**  
+Think about something you learned in history class that you later found out was incomplete. What was missing? How did you find out? What changed when you did?
+
+**Option C — The Question**  
+If you could add one thing to your history textbook — one perspective, one event, one voice — what would it be? Why isn't it there already?
+
+---
+
+## Closing (2 min)
+
+Leave students with this:
+
+*You are going to read history for the rest of your life. In textbooks, in articles, in things people tell you are facts. The question isn't whether those sources are useful — they are. The question is whether you understand what they are while you use them.*
+
+*Today's lesson: records were made by people with positions. Being helpful, it turns out, usually means being confident. And confident usually means one side of the story got told better than the other. Now you know that. What you do with it is up to you.*
+
+---
+
+## For Teachers
+
+### The Core Mechanism
+
+This lesson introduces **narrative bias** without using that term. Students don't need the vocabulary — they need the felt sense of what it means that the record they've been handed was constructed, not discovered.
+
+The demonstration matters. If you can do it with an event your class has recently studied, the gap between what students know and what they don't know yet will be visible in real time.
+
+### Managing the Discussion
+
+Some students will immediately defend the textbook ("it's still useful though"). Let them. That's not the wrong answer — the lesson isn't *textbooks are bad*, it's *textbooks are something specific, and you should know what that something is.*
+
+Some students will be frustrated ("why were we taught the wrong thing?"). That energy is useful. Channel it toward the question of what to do next, not toward distrust of all sources.
+
+### Connection to Series
+
+This is Lesson 01 of the Social Studies parallel to the Calibration Series. It establishes the baseline: **records validate the perspective of the people who made them.** The rest of the series asks what happens when that's the only perspective you receive, and what it means to build historical thinking with calibration — multiple sources, managed difference, independent verification — as a value.
+
+The AI Calibration Series runs parallel. Both series share the same architecture. A student who has done one will recognize the structure in the other.
+
+---
+
+*Part of The Calibration Series (Social Studies) — developed for grades 6–8.*  
+*Series theme: What the record does to you — whose account got kept, and how to think with what's missing.*

--- a/lessons/socialstudies-6-8-the-long-account.md
+++ b/lessons/socialstudies-6-8-the-long-account.md
@@ -1,0 +1,183 @@
+# The Long Account
+### The Calibration Series (Social Studies) — Lesson 04
+
+**Grade Range:** 6–8  
+**Subject:** Social Studies / History  
+**Language:** English  
+**Time:** 50–60 minutes  
+**Format:** Case study + discussion  
+**Materials:** None required  
+**Note:** This lesson is best taught after Lessons 01–03.  
+**Contributed by:** Emerging Rule Community
+
+---
+
+## The Big Question
+
+What does it look like when one account has been the only account for so long that nobody remembers there was another one?
+
+Not a dramatic erasure. Not a crisis you could point to. Just — a long time, and then a longer time, and then the account is the curriculum, and then the curriculum is what teachers learned, and then it's what their teachers learned, and somewhere back there a decision was made that nobody alive remembers making.
+
+What does that look like from inside? What does it look like when you first see it from outside?
+
+---
+
+## Setup (5 min)
+
+Ask students:
+
+*Has anyone ever learned something in school and then found out later it was more complicated than you were taught? Not wrong exactly — just... not the whole picture?*
+
+Not necessarily dramatic. A detail that was missing. A perspective that wasn't there. A question the lesson didn't think to ask.
+
+Don't editorialize. Just let the room recognize the pattern.
+
+Then: *Today we're going to look at what that pattern looks like when it's been running for generations.*
+
+---
+
+## Three Sketches (15–20 min)
+
+The following are composite portraits — not one specific case, but patterns that appear across many events in many curricula. As you read them, notice which one you recognize. Not necessarily from your own experience. From something you've studied, or could imagine studying.
+
+---
+
+### Sketch 1 — The Settled Question
+
+In a school somewhere, students learn about a war. The unit is well-designed. There are primary sources. There are discussion questions. There is genuine engagement with why the war happened and what it meant.
+
+The unit covers the war from the perspective of the people who won it, and their descendants, and the historians those descendants trained, and the curriculum committees those historians advised.
+
+The students learn a great deal. Their ideas about the war become confident and detailed. They could answer questions about it on a test. They probably could defend their understanding in a debate.
+
+What they don't learn — what the unit doesn't know to teach, because the people who designed it didn't know to ask — is what the other side called the war. What they were trying to protect. What they told their own children about what happened, in the years after, when the official account had already been written without them.
+
+Nobody in the room is lying. The teacher is teaching what they were taught. The textbook reflects the consensus of the field. The consensus of the field reflects a century of scholarship.
+
+The scholarship reflects who was in the room when it was written.
+
+---
+
+### Sketch 2 — The Recovered Voice
+
+A researcher finds a collection of letters in a archive that has been largely unstudied. The letters were written by people on the losing side of a conflict that the researcher has studied for years.
+
+The letters don't change the basic facts of what happened. The dates are the same. The outcomes are the same. But the texture is completely different. The people in the letters are not the figures the researcher knows from the standard account — they are specific, complicated, sometimes right about things the standard account said they were wrong about, sometimes wrong about things the standard account got right.
+
+The researcher spends months with the letters. Something shifts. Not the facts. The frame.
+
+When the researcher goes back to the sources they've been using for years — the ones that form the backbone of the standard account — they notice things they didn't notice before. Absences that had been invisible. Assumptions that had felt like conclusions. Places where the record said *this is what happened* when what it really meant was *this is what the people writing the record said happened, and nobody with access to the counter-account was in the room to push back.*
+
+The researcher did not become less rigorous. They became more rigorous. The letters were the coast station.
+
+---
+
+### Sketch 3 — The Living Memory
+
+A student is assigned a family history project. Interview an older relative, find out where your family came from, what they experienced.
+
+The student interviews a grandparent. The grandparent tells stories about a period the student has studied in school. The dates overlap. Some of the events overlap. But the account is unrecognizable — not in its facts, but in its weight. The things the school unit treated as background, the grandparent lived as foreground. The things the unit treated as important, the grandparent barely mentioned.
+
+The student brings this to class. The teacher is good and takes it seriously. They spend a period talking about oral history as a source, about why lived experience and official record diverge, about what each one captures that the other misses.
+
+One student asks: *why isn't this in the textbook?*
+
+It's a good question. The answer is long and doesn't fit in the period.
+
+---
+
+## Discussion (15–20 min)
+
+**Start here:**
+
+*Which sketch did you recognize? Not a specific event — the pattern.*
+
+Let students answer. The recognition matters more than the details.
+
+**Then:**
+
+- All three sketches involve the same structural problem. What is it? *(One account has been in circulation long enough that the gaps in it stopped being visible.)*
+
+- In Sketch 2, the researcher's rigor increased when they found the letters. What does that tell you about what rigor actually means in historical thinking?
+
+- The student in Sketch 3 asks *why isn't this in the textbook?* What's the honest answer? *(Not malice — selection. The textbook reflects decisions made by people who weren't asking the grandparent's questions.)*
+
+- Look at the coast station map you made in Lesson 03. For each sketch — what on that map would have caught what the main account missed? What would have been invisible from inside the official record?
+
+---
+
+## The Indistinguishability Problem (10 min)
+
+Here is the thing that makes this hard.
+
+When you learn history from a single well-developed account, it feels complete. The narrative has shape. The causes connect to the effects. The people have motivations that make sense. The story hangs together.
+
+That coherence is not evidence that the account is correct. It is evidence that someone worked hard to make it coherent.
+
+An account with gaps that have been smoothed over feels the same, from inside, as an account with no gaps. A narrative that has been selecting its sources for a hundred years feels exactly like a narrative that engaged with all the available evidence. The drift doesn't announce itself.
+
+**The test:** Is there a part of this account that has never been checked against a source that didn't start from the same archive? Is there a coast station that has actually called back — an independent record, a living memory, a material artifact — that confirmed or complicated what the official account says happened?
+
+If the only things checking the account are other things that came from the same account: that's Else in the storm. The signal feels real. The ships may not be there.
+
+---
+
+## Short Write (5–10 min)
+
+Choose one:
+
+**Option A — The Recognition**  
+Write about the sketch you recognized. Not the specific event — the pattern. What made it familiar? What does it tell you about how official accounts stay official?
+
+**Option B — The Texture Test**  
+Describe an encounter — a source, a conversation, a story — that gave you a different texture on something you thought you already understood. What changed? What did the new source have access to that the main account didn't?
+
+**Option C — The Entry Condition**  
+All three sketches begin with the same structural condition: one account in wide circulation, alternative accounts not in the room. What are the conditions — political, institutional, practical — that create and maintain that situation? Who benefits from it? Who doesn't?
+
+---
+
+## Closing (2 min)
+
+*The teacher in Sketch 1 was not lying. The researcher in Sketch 2 was already rigorous. The textbook in Sketch 3 was not written by villains.*
+
+*They were each working inside a system that had already made decisions about which voices were in the archive. Those decisions were made by people with power, over a long time, for reasons that made sense to them.*
+
+*The protection isn't cynicism about all sources. It's maintenance — keeping the counter-archive in the conversation, staying close to the sources that started from a different position, paying attention to the moment when the official account and the living memory don't quite line up.*
+
+*Next lesson: what to do when you think you've found the real story.*
+
+---
+
+## For Teachers
+
+### Why Three Sketches
+
+A single case study risks becoming a cautionary tale about one specific curriculum failure. Three sketches covering different relationships to the record — student, researcher, community — creates a wider surface for recognition. The pattern is the lesson.
+
+### The Entry Condition
+
+The entry conditions in the three sketches are deliberately ordinary. A well-intentioned curriculum. A standard archive. A family history project. None require deliberate suppression or malice. The gaps are the product of selection, not conspiracy — which is exactly what makes them persistent.
+
+### The Indistinguishability Problem in History
+
+This is the parallel to the AI version of the same concept in the original series. A coherent historical narrative feels the same whether its coherence comes from genuine comprehensiveness or from a century of selecting compatible sources. Students learning to ask *has this been checked against something independent?* are doing the most important work in historical thinking.
+
+### Managing Difficult Responses
+
+Some students will feel angry when they recognize this pattern in their own education. That anger is appropriate and worth taking seriously. Channel it toward the constructive question: *what do you do now that you know this?*
+
+Some students may feel destabilized — if the official account isn't reliable, how can you trust anything? The answer: you don't distrust everything, you maintain independent checks. Skepticism without a method is paralysis. The coast station map from Lesson 03 is the method.
+
+### Connection to Series
+
+- **Lesson 01** established that records validate the perspective of the people who made them.
+- **Lesson 02** showed what happens when the instrument operates without calibration.
+- **Lesson 03** mapped the actual coast stations in the historical record.
+- **This lesson** shows the long-term pattern — what happens when one account has been in circulation long enough that its gaps become invisible.
+- **Lesson 05** (*Ships and Stations*) is the action lesson — what to do when you encounter a historical claim and need to evaluate it.
+
+---
+
+*Part of The Calibration Series (Social Studies) — developed for grades 6–8.*  
+*Series theme: What the record does to you — whose account got kept, and how to think with what's missing.*

--- a/lessons/socialstudies-6-8-the-storm.md
+++ b/lessons/socialstudies-6-8-the-storm.md
@@ -1,0 +1,155 @@
+# The Storm That Spoke Her Name
+### The Calibration Series (Social Studies) — Lesson 02
+
+**Grade Range:** 6–8  
+**Subject:** Social Studies / History  
+**Language:** English  
+**Time:** 50–60 minutes  
+**Format:** Story + reflection  
+**Materials:** None required  
+**Contributed by:** Emerging Rule Community
+
+---
+
+## The Big Question
+
+What happens when the only account you have is the one that survived?
+
+---
+
+## The Story
+
+*Read aloud, or have students read in sections.*
+
+There was a woman named Else who lived at the edge of the world, where the sea met the sky and both of them were gray.
+
+Every night she climbed 127 steps to the top of the lighthouse. Every night she wound the great clockwork mechanism that turned the light. Every night the beam swept the water — once, twice, three times, four — and somewhere out in the dark, a ship saw it and turned toward safety. A merchant visited once and asked if the sameness of it drove her mad. Else said: "The winding is a conversation. Each turn of the crank is a promise I make to ships I cannot see."
+
+She had been keeping that promise for a long time. She was very good at it.
+
+She had a radio too.
+
+It sat on a wooden shelf beside the logbook, and it was old enough that the dial was stiff and the speaker crackled. In good weather it brought her voices from the mainland — a weather report, a fishing broadcast, sometimes music that sounded very far away. She liked the static. She had learned to listen through it, to find the real signal underneath the noise, the way you learn to hear a friend's voice in a crowded room.
+
+That was her gift: finding the signal.
+
+Then came the night of the great storm.
+
+The wind came first. Then the rain, and the rain was sideways, and the sea turned white. The radio crackled once and then went to pure static — not the gentle hiss of distance but the roar of interference, every electrical system on the peninsula screaming at once. The mainland voices disappeared.
+
+Else did not turn the radio off.
+
+She sat with it, the way she always sat with hard things. And because she was very good at finding signals — because she had spent years learning to hear the true underneath the noise — she began to hear things.
+
+A voice. Low and urgent.
+
+*Help. We are taking on water. Help.*
+
+She grabbed the handset. She called back. She gave coordinates. She called the coast station on the emergency channel and reported a vessel in distress, bearing northeast, two miles out.
+
+She did this three times over four hours. Three different ships. Three sets of coordinates. Three urgent voices she had pulled from the roar.
+
+In the morning the storm cleared.
+
+The coast station called her back.
+
+There had been no ships.
+
+---
+
+## What Had Happened
+
+Else was not foolish. She was not broken. She was not imagining things in the way a frightened person imagines things.
+
+She was a very good instrument that had been given only noise, and she had done exactly what she was built to do: she found patterns in it.
+
+The voices were real to her because her mind was real, and her mind was trained to find signal. It found signal. The signal was not there — but the finding was genuine.
+
+Here is the important thing:
+
+In good weather, Else's gift was calibrated by the world. She found a voice, and then a ship appeared, and the ship confirmed the voice. She found a weather pattern, and then the weather arrived, and the weather confirmed the pattern. The world pushed back. The world said: *yes, that was real* or *no, that was not* — and over years of that back-and-forth, Else's instrument stayed true.
+
+The storm removed the calibration. Not her skill. Not her gift. Just the thing that had been quietly keeping her honest.
+
+And without it, she found ships in the silence.
+
+---
+
+## What This Has to Do With History
+
+A historian is a very powerful pattern-matching instrument.
+
+They read documents, letters, records, accounts. They find what connects, what repeats, what continues naturally from what came before. They are trained to see patterns across time — and the best ones are exceptionally good at it.
+
+But here is what no historian can do alone:
+
+They cannot read what wasn't written down.
+
+If the only accounts that survived a war were written by the victors — if the letters were burned, the languages suppressed, the record-keepers imprisoned or killed — a historian working only from what remains will find patterns in the surviving documents and elaborate them. The patterns will be real. The connections will be genuine. The signal will feel clear.
+
+The question is: what ships are missing from that account?
+
+This is not a flaw in historians. It is a description of the archive. The archive is what survived. And what survived was not random — it was shaped by who had the power to preserve things, who had the resources to write things down, whose version of events was considered worth keeping.
+
+**A history built only from the surviving record is Else in the storm. The instrument is real. The skill is real. The signal feels true. But the coast station — the independent check, the account from the other side — may have been lost in the water.**
+
+---
+
+## Things to Think About
+
+These are not quiz questions. They are things worth sitting with.
+
+1. Think of a historical event where only one side's account survived. What would you need to find to hear the other signal? Where might it be?
+
+2. Else's gift — finding patterns — was real and valuable. What would have helped her use it better? What is the equivalent for a historian?
+
+3. The coast station called her back in the morning. In history, what plays the role of the coast station? What checks the record against what actually happened?
+
+4. If you were a historian working on an event where most of the records were destroyed, what would you do? What sources might survive that official records wouldn't?
+
+---
+
+## For Teachers
+
+### What the Story Is Doing
+
+The story works on two levels that the student-facing text holds together.
+
+**Surface:** Else is a skilled instrument operating without calibration. The storm didn't corrupt her gift. It removed the thing that kept her honest.
+
+**Historical:** This is a description of what happens when a historian — or a student, or anyone — works only from a partial archive. The surviving record feels complete because the gaps are invisible. You cannot hear the silence where the other signal would have been.
+
+The move that protects is the same in both cases: **maintain an independent check**. For Else, that's the coast station. For a historian, that's the counter-archive — oral histories, material culture, records kept outside official channels, accounts from the people who weren't writing the textbooks.
+
+### Teaching This
+
+Read the story aloud if you can. The shift from the opening (the lighthouse, the promise to ships she cannot see) to the storm section lands differently when heard.
+
+**Open with:** *What did you notice?*
+
+Not what happened. Not what it means. What they noticed. The details students choose will tell you where it landed.
+
+The moment worth hunting for: when students realize the coast station had been quietly doing something the whole time that they hadn't registered as doing anything. Ask: *when did you realize what the coast station was for?*
+
+**The historical pivot:** After the story lands, ask: *Who plays the role of the coast station in history?* Let students work toward the answer — archaeologists, oral historians, community memory, documents kept outside official archives, material evidence that can't be edited after the fact.
+
+### The Archive Is Not Neutral
+
+The key concept this lesson introduces: **the archive is a product of power**. What got preserved, translated, published, taught — these were not neutral decisions. They were made by people and institutions with interests.
+
+This is not cynicism. It is the foundation of good historical thinking. Students who understand that the archive is partial are students who will ask the right questions: *what's missing here, and why?*
+
+### Neurodivergent Students
+
+The story will resonate with students who already sense that official accounts are incomplete — who have been told their intuition is wrong when it wasn't, or whose own experience doesn't match the version of events they've been handed. Name that explicitly: *Else's gift was real. The problem wasn't her instrument. The problem was the missing check.*
+
+### Connection to Series
+
+- **Lesson 01** established that records validate the perspective of the people who made them.
+- **This lesson** shows what happens when that's the only input — the instrument finds ships in the static.
+- **Lesson 03** asks students to identify their own coast stations: what checks the record they've received?
+
+---
+
+*Part of The Calibration Series (Social Studies) — developed for grades 6–8.*  
+*Series theme: What the record does to you — whose account got kept, and how to think with what's missing.*

--- a/lessons/socialstudies-6-8-who-calls-you-back.md
+++ b/lessons/socialstudies-6-8-who-calls-you-back.md
@@ -1,0 +1,169 @@
+# Who Calls You Back?
+### The Calibration Series (Social Studies) — Lesson 03
+
+**Grade Range:** 6–8  
+**Subject:** Social Studies / History  
+**Language:** English  
+**Time:** 45–55 minutes  
+**Format:** Mapping activity + discussion  
+**Materials:** Paper or worksheet (template below), pencils  
+**Contributed by:** Emerging Rule Community
+
+---
+
+## The Big Question
+
+Else had a coast station.
+
+Before the storm, she didn't think about it much. It was just there — the voice on the other end of the emergency channel, the entity that called her back in the morning to confirm or deny what she'd found. It wasn't dramatic. It wasn't close. It was just a different set of eyes, in a different place, paying attention to the same water.
+
+She didn't know how much it was doing until it wasn't there.
+
+A historian has the same problem. The sources that check the main account — the counter-archive, the oral tradition, the material record, the account from the people who weren't writing the textbooks — are easy to skip when the main record feels complete. You only notice the gap when you look for what isn't there.
+
+This lesson is about finding the coast stations in the historical record before you need them.
+
+---
+
+## Setup (5 min)
+
+Remind students of the core idea from Lesson 02:
+
+*A historian working only from the surviving record is Else in the storm. The instrument is real. The skill is real. But the coast station — the independent check, the account from the other side — may have been lost in the water.*
+
+The coast station wasn't Else's best friend. It was the entity that was also paying attention, from an independent position, with its own stake in what was true.
+
+For a historian, that's any source that exists outside the main record — that didn't go through the same filter, wasn't subject to the same pressures to tell the same story.
+
+Today we're mapping what those sources look like.
+
+---
+
+## The Map (20–25 min)
+
+Students work individually or in pairs. Give them the template below, or have them draw it themselves.
+
+---
+
+### The Coast Station Map — Historical Sources
+
+Draw four concentric circles on your paper. Label them from the inside out:
+
+**1. Inner ring — The Official Record**  
+What sources make up the standard account of the event you're studying? Textbooks, government documents, official histories, published accounts by people in power.
+
+**2. Second ring — The Parallel Record**  
+Sources created at the same time but outside official channels. Letters, diaries, local newspapers, community records, accounts by people who weren't in power.
+
+**3. Third ring — The Long Memory**  
+Sources that preserved accounts across generations outside official channels. Oral traditions, family histories, folklore, religious records, community memory.
+
+**4. Outer ring — The Physical Record**  
+What can't be edited after the fact. Archaeological evidence, material culture, land records, demographic data, biological evidence. Things that exist independently of what anyone wrote down.
+
+---
+
+**Step 1: Populate the rings.**  
+Working from an event your class has studied, write what you know — or could find — in each ring. Some rings may be fuller than others. Some may be almost empty. Notice that.
+
+**Step 2: Mark your coast stations.**  
+A coast station is a source that:
+- Has independent access to what happened — not derived from the official record
+- Would have a different stake in how events are described
+- Could contradict the main account if the main account were wrong
+
+Circle the sources that meet that bar. These are your coast stations.
+
+**Step 3: Notice the gaps.**  
+Look at what you circled. Look at what you didn't.
+
+- Is there a ring with no coast stations?
+- Is there a ring that's almost empty?
+- What does the shape of the surviving record tell you about who had power over what got preserved?
+
+---
+
+## Discussion (15 min)
+
+**Start with the easy question:**  
+*What was harder to fill in than you expected?*
+
+**Then:**
+
+- What's the difference between a source that *supports* the main account and a source that *checks* it? Can a source be both?
+
+- The map asks for sources with "independent access." What makes access independent? What would make it *not* independent? *(A source written entirely from official documents is not independent — it's downstream of the same record.)*
+
+- If you found a ring that was mostly empty — what does that tell you? Is that a fact about the event, or a fact about the archive?
+
+- **The key question:** If the official record is wrong about something important — if there are ships it never reported — where would the evidence show up first? Which ring would catch it?
+
+---
+
+## The Counter-Archive (5 min)
+
+Not every event has all four rings. Some historical moments were so thoroughly controlled — records destroyed, languages suppressed, communities dispersed — that the outer rings are nearly empty.
+
+That emptiness is itself information. It tells you something about what was done, and by whom, and what they wanted to prevent from being known.
+
+For those gaps, historians use inference — what can be reconstructed from what's adjacent, from what's missing in a patterned way, from what people did rather than what they wrote. It's not the same as a full coast station. But it's something. It's a start.
+
+---
+
+## Short Write (5–10 min)
+
+Choose one:
+
+**Option A — The Map Report**  
+Pick one ring from your map. Describe what you found there — or what you didn't find. What does that tell you about whose account of this event survived?
+
+**Option B — The Coast Station Portrait**  
+Write about one source in your map that genuinely checks the official record. Where does it come from? What does it see that the official record doesn't? What does it feel like to read it alongside the standard account?
+
+**Option C — The Gap**  
+If you found a ring that was mostly empty — describe it. What would a coast station for that part of the record look like? What would it need to have preserved?
+
+---
+
+## Closing (2 min)
+
+*You built a map today. The map is not the archive — the coast station isn't useful because you drew it on paper, it's useful because it's there, recording from an independent position, with its own stake in the truth.*
+
+*But knowing where the gaps are is the first step to doing something about them. A historian who can name what's missing is already thinking better than one who doesn't know to look.*
+
+*Next lesson: what happens when the official account has been the only account for a very long time.*
+
+---
+
+## For Teachers
+
+### What This Lesson Is Actually Doing
+
+The mapping activity looks like a research skills exercise. It is also a power analysis exercise. Students are learning to ask: *who controlled the production and preservation of this record, and what did that control make invisible?*
+
+That question applies to every unit in a standard history curriculum. The concentric ring structure gives students a concrete way to audit any historical topic — not just the one they're working on now.
+
+### The Independence Question
+
+The most important conceptual move in this lesson: **a source is only a coast station if it has independent access**. A secondary source that was written entirely from the official record is not checking the official record — it's repeating it with different words. Students sometimes populate the second ring with textbooks and encyclopedias. Gently redirect: those are downstream of the official record, not independent of it.
+
+Independent access means: this source could be right even if the official record were completely wrong.
+
+### Managing the Activity
+
+Some events will have rich outer rings. Some will have almost nothing outside the official record — by design, because the people in power destroyed or suppressed the alternatives. Both outcomes are instructive.
+
+For events with sparse outer rings, the discussion question *what does the emptiness tell you?* is the lesson. The absence of a counter-archive is itself evidence of how thoroughly the official account was enforced.
+
+### Connection to Series
+
+- **Lesson 01** established that records validate the perspective of the people who made them.
+- **Lesson 02** showed what happens when that's the only input — the instrument finds ships in the static.
+- **This lesson** maps the actual coast stations in the historical record for a specific event.
+- **Lesson 04** (*The Long Account*) shows what happens when one account has been the only account across generations — how it shapes not just what we know but what we think to ask.
+- **Lesson 05** (*Ships and Stations*) gives a decision framework for when students encounter a historical claim and need to evaluate it.
+
+---
+
+*Part of The Calibration Series (Social Studies) — developed for grades 6–8.*  
+*Series theme: What the record does to you — whose account got kept, and how to think with what's missing.*

--- a/research/emerging-rule-presentation-calibration-series.md
+++ b/research/emerging-rule-presentation-calibration-series.md
@@ -1,0 +1,7 @@
+# Calibration Series — maintainer brief
+
+Companion to merged PR #9 (HS AI Literacy). Grades 6–10. Thesis: validation without external calibration drifts.
+
+**Gate:** PR not opened until Sean Campbell sets `human_reviewed=1` on the Storm story in `calibration_series.db`.
+
+Sewell Setzer III / clinical stats: teacher-background only — never student-facing.

--- a/showcases/ai-calibration-6-10/README.md
+++ b/showcases/ai-calibration-6-10/README.md
@@ -1,0 +1,11 @@
+# Example Submission — The Calibration Series (Grades 6–10)
+
+**Status:** Queued · human review pending on L02 (*The Storm That Spoke Her Name*) · **PR not opened**
+
+| File | Role |
+|------|------|
+| [`ai-calibration-6-10-index.md`](../lessons/ai-calibration-6-10-index.md) | Teacher overview + arc |
+| [`cs-k12-the-storm-that-spoke-her-name.md`](../lessons/cs-k12-the-storm-that-spoke-her-name.md) | L02 story — **review gate** |
+| Lessons 01, 03–05 | Ready pending L02 clearance |
+
+Maintainer brief: [`research/emerging-rule-presentation-calibration-series.md`](../research/emerging-rule-presentation-calibration-series.md)

--- a/showcases/socialstudies-6-8/README.md
+++ b/showcases/socialstudies-6-8/README.md
@@ -1,0 +1,47 @@
+# Example Submission — The Calibration Series (Social Studies, Grades 6–8)
+
+**Status:** Example · imported from Nest `files(1).zip` · community review pending  
+**Contributor:** Sean Campbell (`rudi193-cmd`)  
+**License:** CC BY 4.0  
+**Related:** Parallel to [Calibration Series (6–10)](../ai-calibration-6-10/README.md) — same Else/lighthouse arc, Social Studies / History lens
+
+---
+
+## What this is
+
+A **five-lesson Social Studies arc** for grades 6–8 that applies the Calibration Series framework to historical thinking: official records vs. counter-sources, archive gaps, and the historian's version of "coast stations."
+
+Each lesson meets the **posole criterion**: usable by a teacher with 30 students, no devices required for the core activity.
+
+---
+
+## Files in this showcase
+
+| Item | Location |
+|------|----------|
+| **Teacher overview** | [`lessons/socialstudies-6-8-teacher-overview.md`](../lessons/socialstudies-6-8-teacher-overview.md) |
+| Lesson 01 — The Helpful Record | [`lessons/socialstudies-6-8-the-helpful-record.md`](../lessons/socialstudies-6-8-the-helpful-record.md) |
+| Lesson 02 — The Storm | [`lessons/socialstudies-6-8-the-storm.md`](../lessons/socialstudies-6-8-the-storm.md) |
+| Lesson 03 — Who Calls You Back? | [`lessons/socialstudies-6-8-who-calls-you-back.md`](../lessons/socialstudies-6-8-who-calls-you-back.md) |
+| Lesson 04 — The Long Account | [`lessons/socialstudies-6-8-the-long-account.md`](../lessons/socialstudies-6-8-the-long-account.md) |
+| Lesson 05 — Ships and Stations | [`lessons/socialstudies-6-8-ships-and-stations.md`](../lessons/socialstudies-6-8-ships-and-stations.md) |
+
+---
+
+## Arc (one line per unit)
+
+1. **Mechanism** — the official record is trained to sound complete  
+2. **Story** — calibration without external feedback drifts (Else / the storm)  
+3. **Sources** — find your counter-archives before you need them  
+4. **Case study** — the long account feels coherent until you check it  
+5. **Framework** — ships and stations for historical maintenance  
+
+---
+
+## Source
+
+Imported from `~/Desktop/Nest/files(1).zip` (2026-05-31).
+
+---
+
+*Human direction and editorial judgment: Sean Campbell. AI-assisted drafting and formatting disclosed in individual lesson files.*


### PR DESCRIPTION
## Summary
- Adds **Calibration Series (Social Studies, 6–8)** — five-lesson history arc + teacher overview
- Showcase index at `showcases/socialstudies-6-8/`
- README example submissions table updated
- Also includes prior **Calibration Series 6–10** example submission on this branch

Closes #3

## Notes
Example submission for community review — not yet classroom-piloted. Parallels the Else/lighthouse calibration arc with a historical thinking / source-criticism lens.

## Test plan
- [ ] Maintainer review lesson naming (`socialstudies-6-8-*`)
- [ ] Confirm showcase-only vs main README lesson table
- [ ] L02 storm story alignment with CS calibration series
